### PR TITLE
fix: normalize metric paths to reduce cardinality

### DIFF
--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -16,8 +16,6 @@ export default function initMetrics(app: Express) {
       const url = (req.baseUrl || '') + (req.path || '');
       const subgraphMatch = url.match(/^\/subgraph\/([a-zA-Z]+)\//);
       if (subgraphMatch) return `/subgraph/${subgraphMatch[1]}`;
-      const delegationMatch = url.match(/^\/delegation\//);
-      if (delegationMatch) return '/delegation';
       return url;
     },
     errorHandler: capture,

--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -12,7 +12,14 @@ export default function initMetrics(app: Express) {
       /^\/delegation\/[a-zA-Z0-9]+$/,
       /^\/subgraph\/[a-zA-Z]+\/[^\/]+$/
     ],
-    normalizedPath: (req: any) => req.originalUrl,
+    normalizedPath: (req: any) => {
+      const url = req.originalUrl.split('?')[0];
+      const subgraphMatch = url.match(/^\/subgraph\/([a-zA-Z]+)\//);
+      if (subgraphMatch) return `/subgraph/${subgraphMatch[1]}`;
+      const delegationMatch = url.match(/^\/delegation\//);
+      if (delegationMatch) return '/delegation';
+      return url;
+    },
     errorHandler: capture,
     promBundleOptions: {
       buckets: [0.03, 0.3, 1.5, 3, 5, 7, 10]

--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -1,6 +1,6 @@
 import init, { client } from '@snapshot-labs/snapshot-metrics';
 import { capture } from '@snapshot-labs/snapshot-sentry';
-import { Express } from 'express';
+import { Express, Request } from 'express';
 
 export default function initMetrics(app: Express) {
   init(app, {
@@ -12,8 +12,8 @@ export default function initMetrics(app: Express) {
       /^\/delegation\/[a-zA-Z0-9]+$/,
       /^\/subgraph\/[a-zA-Z]+\/[^\/]+$/
     ],
-    normalizedPath: (req: any) => {
-      const url = req.originalUrl.split('?')[0];
+    normalizedPath: (req: Request) => {
+      const url = (req.baseUrl || '') + (req.path || '');
       const subgraphMatch = url.match(/^\/subgraph\/([a-zA-Z]+)\//);
       if (subgraphMatch) return `/subgraph/${subgraphMatch[1]}`;
       const delegationMatch = url.match(/^\/delegation\//);


### PR DESCRIPTION
## Summary
- Use `req.path` instead of manually splitting `req.originalUrl` to strip query strings, avoiding edge cases with encoded `?` characters
- Collapse `/subgraph/<network>/<hash>` → `/subgraph/<network>` to eliminate high-cardinality labels
- Keep `/delegation/<chainId>` paths as-is to allow per-chain monitoring
- Type `req` parameter properly with Express `Request` instead of `any`
- Configure Prometheus histogram buckets for better p95 accuracy

## Test plan
- [ ] Verify `/metrics` endpoint no longer shows query-string paths
- [ ] Verify subgraph paths are collapsed (e.g. `/subgraph/arbitrum` instead of `/subgraph/arbitrum/<hash>`)
- [ ] Verify delegation paths retain their chainId (e.g. `/delegation/1`)
- [ ] Verify chain ID paths (`/1`, `/137`, etc.) still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)