### PR TITLE
fix: strip trailing slashes in metric paths

### DIFF
--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -6,16 +6,18 @@ export default function initMetrics(app: Express) {
   init(app, {
     whitelistedPath: [
       /^\/$/,
-      /^\/\d+$/,
-      /^\/sn$/,
-      /^\/sn-sep$/,
-      /^\/delegation\/[a-zA-Z0-9]+$/,
-      /^\/subgraph\/[a-zA-Z]+\/[^\/]+$/
+      /^\/\d+\/?$/,
+      /^\/sn\/?$/,
+      /^\/sn-sep\/?$/,
+      /^\/delegation\/[a-zA-Z0-9]+\/?$/,
+      /^\/subgraph\/[a-zA-Z]+\/[^\/]+\/?$/
     ],
     normalizedPath: (req: Request) => {
-      const url = (req.baseUrl || '') + (req.path || '');
-      const subgraphMatch = url.match(/^\/subgraph\/([a-zA-Z]+)\//);
+      const url = ((req.baseUrl || '') + (req.path || '')).replace(/\/+$/, '') || '/';
+      const subgraphMatch = url.match(/^\/subgraph\/([a-zA-Z]+)(\/|$)/);
       if (subgraphMatch) return `/subgraph/${subgraphMatch[1]}`;
+      const delegationMatch = url.match(/^\/delegation(\/|$)/);
+      if (delegationMatch) return '/delegation';
       return url;
     },
     errorHandler: capture,

--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -17,8 +17,6 @@ export default function initMetrics(app: Express) {
       const url = raw.length > 1 ? raw.replace(/\/+$/, '') : raw;
       const subgraphMatch = url.match(/^\/subgraph\/([a-zA-Z]+)(\/|$)/);
       if (subgraphMatch) return `/subgraph/${subgraphMatch[1]}`;
-      const delegationMatch = url.match(/^\/delegation(\/|$)/);
-      if (delegationMatch) return '/delegation';
       return url;
     },
     errorHandler: capture,

--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -14,8 +14,8 @@ export default function initMetrics(app: Express) {
     ],
     normalizedPath: (req: Request) => {
       const raw = (req.baseUrl || '') + (req.path || '');
-      const url = raw.length > 1 ? raw.replace(/\/+$/, '') : raw;
-      const subgraphMatch = url.match(/^\/subgraph\/([a-zA-Z]+)(\/|$)/);
+      const url = raw.length > 1 && raw.endsWith('/') ? raw.slice(0, -1) : raw;
+      const subgraphMatch = url.match(/^\/subgraph\/([a-zA-Z]+)$/);
       if (subgraphMatch) return `/subgraph/${subgraphMatch[1]}`;
       return url;
     },

--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -13,7 +13,8 @@ export default function initMetrics(app: Express) {
       /^\/subgraph\/[a-zA-Z]+\/[^\/]+\/?$/
     ],
     normalizedPath: (req: Request) => {
-      const url = ((req.baseUrl || '') + (req.path || '')).replace(/\/+$/, '') || '/';
+      const raw = (req.baseUrl || '') + (req.path || '');
+      const url = raw.length > 1 ? raw.replace(/\/+$/, '') : raw;
       const subgraphMatch = url.match(/^\/subgraph\/([a-zA-Z]+)(\/|$)/);
       if (subgraphMatch) return `/subgraph/${subgraphMatch[1]}`;
       const delegationMatch = url.match(/^\/delegation(\/|$)/);


### PR DESCRIPTION
## Summary
- Strip trailing slashes in `normalizedPath` so `/1/` and `/1` both record as `/1`
- Fix whitelist regexes to match paths with optional trailing slashes (`\/?`)

## Before (with #529)
- `/1` → recorded as `/1` ✓
- `/1/` → silently dropped by whitelist (not recorded)
- `/1?x=a` → recorded as `/1?x=a` (query string leaked into label)
- `/1/?x=a` → silently dropped by whitelist

## After (with #530)
All 4 variants collapse into `/1`:
- `/1` → whitelist matches → normalizedPath = `/1`
- `/1/` → whitelist matches → normalizedPath strips slash → `/1`
- `/1?x=a` → `req.path` = `/1` → normalizedPath = `/1`
- `/1/?x=a` → `req.path` = `/1/` → normalizedPath strips slash → `/1`

## Test plan
- [ ] After deploy, verify Prometheus shows clean paths without trailing slashes
- [ ] Verify no duplicate path labels (e.g. `/1` and `/1/`)
- [ ] Verify query strings no longer leak into path labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)