### PR TITLE
fix: restore subgraph path normalization regex

### DIFF
--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -6,16 +6,18 @@ export default function initMetrics(app: Express) {
   init(app, {
     whitelistedPath: [
       /^\/$/,
-      /^\/\d+$/,
-      /^\/sn$/,
-      /^\/sn-sep$/,
-      /^\/delegation\/[a-zA-Z0-9]+$/,
-      /^\/subgraph\/[a-zA-Z]+\/[^\/]+$/
+      /^\/\d+\/?$/,
+      /^\/sn\/?$/,
+      /^\/sn-sep\/?$/,
+      /^\/delegation\/[a-zA-Z0-9]+\/?$/,
+      /^\/subgraph\/[a-zA-Z]+\/[^\/]+\/?$/
     ],
     normalizedPath: (req: Request) => {
-      const url = (req.baseUrl || '') + (req.path || '');
-      const subgraphMatch = url.match(/^\/subgraph\/([a-zA-Z]+)\//);
+      const url = ((req.baseUrl || '') + (req.path || '')).replace(/\/+$/, '') || '/';
+      const subgraphMatch = url.match(/^\/subgraph\/([a-zA-Z]+)(\/|$)/);
       if (subgraphMatch) return `/subgraph/${subgraphMatch[1]}`;
+      const delegationMatch = url.match(/^\/delegation(\/|$)/);
+      if (delegationMatch) return '/delegation';
       return url;
     },
     errorHandler: capture,

--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -17,8 +17,6 @@ export default function initMetrics(app: Express) {
       const url = raw.length > 1 ? raw.replace(/\/+$/, '') : raw;
       const subgraphMatch = url.match(/^\/subgraph\/([a-zA-Z]+)(\/|$)/);
       if (subgraphMatch) return `/subgraph/${subgraphMatch[1]}`;
-      const delegationMatch = url.match(/^\/delegation(\/|$)/);
-      if (delegationMatch) return '/delegation';
       return url;
     },
     errorHandler: capture,

--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -14,8 +14,8 @@ export default function initMetrics(app: Express) {
     ],
     normalizedPath: (req: Request) => {
       const raw = (req.baseUrl || '') + (req.path || '');
-      const url = raw.length > 1 ? raw.replace(/\/+$/, '') : raw;
-      const subgraphMatch = url.match(/^\/subgraph\/([a-zA-Z]+)(\/|$)/);
+      const url = raw.length > 1 && raw.endsWith('/') ? raw.slice(0, -1) : raw;
+      const subgraphMatch = url.match(/^\/subgraph\/([a-zA-Z]+)$/);
       if (subgraphMatch) return `/subgraph/${subgraphMatch[1]}`;
       return url;
     },

--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -15,7 +15,7 @@ export default function initMetrics(app: Express) {
     normalizedPath: (req: Request) => {
       const raw = (req.baseUrl || '') + (req.path || '');
       const url = raw.length > 1 && raw.endsWith('/') ? raw.slice(0, -1) : raw;
-      const subgraphMatch = url.match(/^\/subgraph\/([a-zA-Z]+)$/);
+      const subgraphMatch = url.match(/^\/subgraph\/([a-zA-Z]+)\//);
       if (subgraphMatch) return `/subgraph/${subgraphMatch[1]}`;
       return url;
     },

--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -13,7 +13,8 @@ export default function initMetrics(app: Express) {
       /^\/subgraph\/[a-zA-Z]+\/[^\/]+\/?$/
     ],
     normalizedPath: (req: Request) => {
-      const url = ((req.baseUrl || '') + (req.path || '')).replace(/\/+$/, '') || '/';
+      const raw = (req.baseUrl || '') + (req.path || '');
+      const url = raw.length > 1 ? raw.replace(/\/+$/, '') : raw;
       const subgraphMatch = url.match(/^\/subgraph\/([a-zA-Z]+)(\/|$)/);
       if (subgraphMatch) return `/subgraph/${subgraphMatch[1]}`;
       const delegationMatch = url.match(/^\/delegation(\/|$)/);


### PR DESCRIPTION
## Summary
- The subgraph regex was incorrectly simplified from `/^\/subgraph\/([a-zA-Z]+)\//` to `/^\/subgraph\/([a-zA-Z]+)$/` in #530
- The `$` anchor never matches because subgraph URLs have a hash segment after the network name (e.g. `/subgraph/arbitrum/52uVpyUH...`)
- Restores the original `/` match so paths collapse to `/subgraph/arbitrum`

## Test plan
- [ ] Verify subgraph paths show as `/subgraph/arbitrum` instead of full hash URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)