### PR TITLE
fix: restore subgraph path normalization broken by #530

### DIFF
--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -15,7 +15,7 @@ export default function initMetrics(app: Express) {
     normalizedPath: (req: Request) => {
       const raw = (req.baseUrl || '') + (req.path || '');
       const url = raw.length > 1 && raw.endsWith('/') ? raw.slice(0, -1) : raw;
-      const subgraphMatch = url.match(/^\/subgraph\/([a-zA-Z]+)$/);
+      const subgraphMatch = url.match(/^\/subgraph\/([a-zA-Z]+)\//);
       if (subgraphMatch) return `/subgraph/${subgraphMatch[1]}`;
       return url;
     },


### PR DESCRIPTION
## Summary

#530 introduced a regression in subgraph path normalization.

The subgraph regex was changed from `(\/|$)` to `$` to remove what appeared to be a dead branch (since trailing slashes were being stripped, the `\/` alternative seemed unreachable). However, this broke normalization entirely because subgraph URLs have a hash segment after the network name:

```
/subgraph/arbitrum/52uVpyUHkkMFieRk1khbdshUw26CNHWAEuqLojZzcyjd
```

The `$` anchor requires the URL to end after the network name, which never happens. As a result, **no subgraph paths are being normalized** — full hashes leak into metric labels, causing high cardinality.

### Before #530 (working)
`/subgraph/arbitrum/HASH` → `/subgraph/arbitrum` ✅

### After #530 (broken)
`/subgraph/arbitrum/HASH` → `/subgraph/arbitrum/HASH` ❌

### After this fix
Restores `\/` match so subgraph paths correctly normalize to `/subgraph/{network}`.

## Test plan
- [ ] After deploy, verify subgraph metrics show `/subgraph/arbitrum` instead of full hash URLs
- [ ] Confirm via `count by(path) (http_request_duration_seconds_count{instance=~"rpc.brovider.xyz:.*", path=~"/subgraph/.*"})` that only network-level labels exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)