### PR TITLE
chore: stop reporting upstream RPC/subgraph failures to Sentry

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.842.0",
     "@ethersproject/providers": "^5.7.2",
+    "@sentry/node": "^7.81.1",
     "@snapshot-labs/snapshot-metrics": "^1.4.1",
     "@snapshot-labs/snapshot-sentry": "^1.5.5",
     "body-parser": "^2.2.0",

--- a/src/helpers/sentry.ts
+++ b/src/helpers/sentry.ts
@@ -1,0 +1,33 @@
+import * as Sentry from '@sentry/node';
+
+const TRANSIENT_UPSTREAM_CODES = new Set([
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'ESOCKETTIMEDOUT',
+  'EAI_AGAIN',
+  'ENOTFOUND',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  'EPIPE',
+  'EPROTO',
+  'CERT_HAS_EXPIRED',
+  'ERR_TLS_CERT_ALTNAME_INVALID'
+]);
+
+function isTransientUpstreamError(err: any): boolean {
+  if (!err) return false;
+  if (err.code && TRANSIENT_UPSTREAM_CODES.has(err.code)) return true;
+  if (err.name === 'AggregateError' && Array.isArray(err.errors)) {
+    return err.errors.every((e: any) => isTransientUpstreamError(e));
+  }
+  return false;
+}
+
+// Drop unfixable upstream RPC failures before Sentry — third-party network conditions, not brovider bugs.
+export function initSentryFilters() {
+  Sentry.addGlobalEventProcessor((event, hint) => {
+    if (isTransientUpstreamError(hint?.originalException)) return null;
+    return event;
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import cors from 'cors';
 import express from 'express';
 import initMetrics from './helpers/metrics';
 import { run as loadData } from './helpers/nodes';
+import { initSentryFilters } from './helpers/sentry';
 import rpc from './rpc';
 import pkg from '../package.json';
 
@@ -11,6 +12,7 @@ const app = express();
 const PORT = process.env.PORT || 3000;
 
 initLogger(app);
+initSentryFilters();
 initMetrics(app);
 loadData();
 

--- a/src/middlewares/processGraphql.ts
+++ b/src/middlewares/processGraphql.ts
@@ -24,8 +24,6 @@ export async function graphqlQuery(url: string, query: string, variables = {}) {
   try {
     responseData = JSON.parse(responseData);
   } catch (e) {
-    capture({ error: { code: res.status, message: res.statusText } }, { url });
-
     if (!res.ok) {
       throw new Error(`Unable to connect to ${url}, code: ${res.status}`);
     } else {
@@ -110,7 +108,6 @@ export default async function processGraphql(req: Request, res: Response, next: 
       shouldCache
     ]);
     if (result.errors) {
-      capture(new Error('GraphQl error'), result.errors);
       return next(SubgraphError.fromGraphQLResult(result, 400));
     }
     return res.json(result);


### PR DESCRIPTION
## Summary

Brovider currently emits ~47k Sentry events per 30 days, accounting for >80% of the `snapshot-labs` org's quota. All of the top issues are upstream/network failures that brovider cannot fix:

| Issue | Title | Events (30d) | Lifetime |
|---|---|---|---|
| BROVIDER-Q | `Error: GraphQl error` | 27,095 | 65,855 |
| BROVIDER-F | `AggregateError` on POST /42161 | 19,878 | 360,930 |
| BROVIDER-D | DNS lookup failures (`EAI_AGAIN`/`ENOTFOUND`) | 52 | 120,054 |
| BROVIDER-P | `ECONNREFUSED` to upstream RPC | 76 | 887 |
| BROVIDER-X | `ERR_TLS_CERT_ALTNAME_INVALID` | 0 (stale) | 70,058 |

This PR makes two surgical changes that should eliminate all five — without changing any user-facing response behavior.

### 1. `src/middlewares/processGraphql.ts`
Removed two `capture()` calls that reported every upstream subgraph failure. The errors are still returned to the client via `SubgraphError` / `SubgraphError.fromGraphQLResult` — only the Sentry noise is dropped. → kills **BROVIDER-Q**.

### 2. `src/helpers/sentry.ts` (new) + `src/index.ts`
Added a `Sentry.addGlobalEventProcessor` that drops events whose `originalException` carries a transient upstream code (`ECONNREFUSED`, `ECONNRESET`, `ETIMEDOUT`, `EAI_AGAIN`, `ENOTFOUND`, `EHOSTUNREACH`, `ENETUNREACH`, `EPIPE`, `EPROTO`, `CERT_HAS_EXPIRED`, `ERR_TLS_CERT_ALTNAME_INVALID`) or an `AggregateError` composed of those codes. The filter logic lives in a new helper exporting `initSentryFilters()`, which `index.ts` calls right after `initLogger(app)`. Events filtered this way are dropped client-side before transmission, so they don't count toward quota. The proxy code path and the user-facing response (`500` with Sentry trace ID, same as today) are untouched. → kills **BROVIDER-F**, **-D**, **-P**, **-X**.

`@sentry/node` is added as a direct dep (matching the `^7.81.1` already pulled in transitively by `@snapshot-labs/snapshot-sentry`) so the import is explicit rather than relying on a transitive resolution.

## Sentry issues resolved on merge

Fixes SNAPSHOT-LABS-BROVIDER-Q
Fixes SNAPSHOT-LABS-BROVIDER-F
Fixes SNAPSHOT-LABS-BROVIDER-D
Fixes SNAPSHOT-LABS-BROVIDER-P
Fixes SNAPSHOT-LABS-BROVIDER-X

- Fixes [BROVIDER-Q](https://snapshot-labs.sentry.io/issues/BROVIDER-Q/)
- Fixes [BROVIDER-F](https://snapshot-labs.sentry.io/issues/BROVIDER-F/)
- Fixes [BROVIDER-D](https://snapshot-labs.sentry.io/issues/BROVIDER-D/)
- Fixes [BROVIDER-P](https://snapshot-labs.sentry.io/issues/BROVIDER-P/)
- Fixes [BROVIDER-X](https://snapshot-labs.sentry.io/issues/BROVIDER-X/)

## Test plan

- [x] `yarn typecheck`
- [x] `yarn lint`
- [ ] `yarn test` (locally requires Postgres; CI should run it)
- [ ] After merge & deploy, confirm BROVIDER-Q stops accumulating new events
- [ ] After merge & deploy, confirm BROVIDER-F stops accumulating new events
- [ ] Verify a non-network 5xx (e.g. throw a TypeError in middleware) still reaches Sentry — only transient upstream errors should be filtered

## Follow-ups (not in this PR)

- Prune dead RPC endpoints from `src/rpcs.json` (`pyrus2.ubiqscan.io`, `network-archive.ambrosus.io`, `kai-internal.kardiachain.io`, `starknet-mainnet.infura.io`, `edge.goldsky.com`) so we stop generating real upstream errors before they get filtered.