### PR TITLE
test: switch e2e RPC to publicnode and tolerate upstream wording drift

### DIFF
--- a/tests/e2e/delegation.test.ts
+++ b/tests/e2e/delegation.test.ts
@@ -91,7 +91,7 @@ describe('Delegation Endpoints', () => {
         const response = await request(app).post('/delegation/1').send(invalidGraphqlQuery);
 
         expect(response.status).toBe(400);
-        expect(response.body).toEqual({
+        expect(response.body).toMatchObject({
           errors: [
             {
               message: 'Type `Query` has no field `invalidField`'

--- a/tests/e2e/network.test.ts
+++ b/tests/e2e/network.test.ts
@@ -131,12 +131,12 @@ describe('Network Endpoint E2E Tests', () => {
           })
           .expect(200);
 
-        expect(response.body).toEqual({
+        expect(response.body).toMatchObject({
           id: 2,
           jsonrpc: '2.0',
           error: {
             code: expect.any(Number),
-            message: expect.stringContaining('not supported')
+            message: expect.stringMatching(/not (supported|available|found)|does not exist/i)
           }
         });
       });
@@ -152,13 +152,12 @@ describe('Network Endpoint E2E Tests', () => {
           })
           .expect(200);
 
-        expect(response.body).toEqual({
+        expect(response.body).toMatchObject({
           id: 1,
           jsonrpc: '2.0',
           error: {
             code: -32602,
-            message: expect.stringMatching(/invalid/i),
-            data: expect.anything()
+            message: expect.stringMatching(/invalid/i)
           }
         });
       });

--- a/tests/e2e/subgraph.test.ts
+++ b/tests/e2e/subgraph.test.ts
@@ -71,7 +71,7 @@ describe('Subgraph Endpoints', () => {
           .send(invalidGraphqlQuery);
 
         expect(response.status).toBe(400);
-        expect(response.body).toEqual({
+        expect(response.body).toMatchObject({
           errors: [
             {
               message: 'Type `Query` has no field `invalidField`'

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -18,7 +18,7 @@ async function insertTestData() {
 
     // Insert nodes data
     const nodeData = [
-      { network: '1', url: 'https://eth.llamarpc.com', main: 1 },
+      { network: '1', url: 'https://ethereum-rpc.publicnode.com', main: 1 },
       { network: '10', url: 'https://mainnet.optimism.io', main: 1 },
       { network: '56', url: 'https://bsc-dataseed.binance.org', main: 1 },
       { network: '137', url: 'https://polygon-rpc.com', main: 1 },


### PR DESCRIPTION
## Summary

The e2e suite was failing in CI for two unrelated reasons, both caused by upstream behavior changes — not by code in this repo:

1. **`eth.llamarpc.com` started returning 403 to GitHub Actions runner IPs**, which broke the 4 proxied-method tests in `network.test.ts`. The endpoint is healthy from non-CI IPs (\`curl\` from a workstation returns 200) but llamarpc has begun rate-limiting / blocking the GitHub-hosted runner range.
2. **The Graph gateway started including a \`locations\` field on GraphQL error responses**, which broke the 2 "invalid GraphQL syntax" tests in \`subgraph.test.ts\` and \`delegation.test.ts\` (they used strict \`toEqual\`).

## Changes

- **\`tests/setup.ts\`**: chainId 1 now points at \`https://ethereum-rpc.publicnode.com\` instead of \`https://eth.llamarpc.com\`. PublicNode is JSON-RPC compliant, free, no API key, runs on Allnodes infrastructure, and doesn't block CI IP ranges. I also probed Cloudflare, Ankr, DRPC, 1RPC, BlastAPI, BlockPI, MEV-Free, and Flashbots — PublicNode was the most spec-compliant of the bunch (Cloudflare's eth_blockNumber returns -32046 "Cannot fulfill request"; Ankr requires an API key; others return 4xx or non-JSON for invalid methods).
- **\`tests/e2e/network.test.ts\`**: two assertion adjustments so the suite isn't tied to one provider's exact wording:
  - \`should return error for invalid method\`: \`expect.stringContaining('not supported')\` → \`expect.stringMatching(/not (supported|available|found)|does not exist/i)\`. PublicNode says "does not exist/is not available"; other providers vary.
  - \`should return error -32602 for invalid parameters\`: dropped \`data: expect.anything()\`. The JSON-RPC spec lists \`data\` as optional and PublicNode omits it; the test still asserts \`code: -32602\` and an "invalid"-matching message, which is the actual contract.
  - Both assertions also switched from \`toEqual\` → \`toMatchObject\` so future upstream-added fields don't re-break them.
- **\`tests/e2e/subgraph.test.ts\` + \`tests/e2e/delegation.test.ts\`**: switched the two \"invalid GraphQL syntax\" assertions from \`toEqual\` → \`toMatchObject\` so the new \`locations\` field returned by The Graph doesn't break them. The asserted message is unchanged.

These are kept as **real e2e tests** — they still hit live upstreams, they're just no longer pinned to a provider that blocks CI or to exact-shape responses that drift over time.

## Test plan

- [x] \`yarn typecheck\`
- [x] \`yarn lint\`
- [x] CI runs the e2e suite end-to-end
- [x] Verify all 25 tests pass (including the 6 that were previously failing)

## Context

Discovered while investigating CI failures on #533 (Sentry quota reduction). Filing as a separate PR per maintainer request — these test changes aren't related to the Sentry work and shouldn't block it.