### PR TITLE
chore: add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "@snapshot-labs/*"


### PR DESCRIPTION
brovider has no `.github/dependabot.yml`, so Dependabot doesn't manage it — stale `@snapshot-labs/eslint-config[-base]` bump PRs (#419, #420) accumulated and Dependabot itself reported it couldn't rebase them ("the dependabot.yml entry that created this PR has been removed"). #419/#420 were closed manually.

This adds the standard Dependabot config used across the other Node services (`score-api`, `snapshot-relayer`, `snapshot-sequencer`): daily npm updates, scoped to `@snapshot-labs/*` only.

```yaml
version: 2
updates:
  - package-ecosystem: "npm"
    directory: "/"
    schedule:
      interval: "daily"
    allow:
      - dependency-name: "@snapshot-labs/*"
```