### PR TITLE
chore: scope tsc compilation to src/ only

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,6 @@
     "inlineSources": true,
     "sourceRoot": "/",
     "skipLibCheck": true
-  }
+  },
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
## Summary
- Adds `"include": ["src/**/*"]` to `tsconfig.json` so `tsc` no longer compiles `tests/**/*.test.ts` into `dist/tests/`.

## Why
Without `include`, tsc defaults to compiling every `.ts` file under `rootDir`, leaving 3 stale test artifacts in `dist/tests/`. The runtime entry is `dist/src/index.js`, so only `src/` needs to be compiled.

## Verification
- `rm -rf dist && yarn build` — no `*.test.js` / `*.spec.js` files in `dist/` (was 3 before)
- `yarn typecheck` passes