### PR TITLE
fix: proxy eth_chainId for non-decimal networks

### DIFF
--- a/src/middlewares/setNode.ts
+++ b/src/middlewares/setNode.ts
@@ -15,7 +15,7 @@ export default function setNode(req: Request, res: Response, next: NextFunction)
   const network = req.params[0];
   const body = req.body || {};
   const { jsonrpc, id } = body;
-  const url = nodes[network];
+  const url = Object.hasOwn(nodes, network) ? nodes[network] : undefined;
 
   if (!req.body || !jsonrpc) {
     return res.status(400).json({ error: 'Invalid request' });

--- a/src/middlewares/withCachedEthChain.ts
+++ b/src/middlewares/withCachedEthChain.ts
@@ -5,7 +5,7 @@ export default function withCachedEthChain(req: Request, res: Response, next: Ne
   const network = req.params[0];
   const { method, jsonrpc, id } = req.body || {};
 
-  if (method === 'eth_chainId') {
+  if (method === 'eth_chainId' && /^\d+$/.test(network)) {
     // Check if network exists before returning cached response
     if (!nodes[network]) {
       return res.status(404).json({ jsonrpc, id, error: 'Invalid network' });

--- a/src/middlewares/withCachedEthChain.ts
+++ b/src/middlewares/withCachedEthChain.ts
@@ -7,7 +7,7 @@ export default function withCachedEthChain(req: Request, res: Response, next: Ne
 
   if (method === 'eth_chainId' && /^\d+$/.test(network)) {
     // Check if network exists before returning cached response
-    if (!nodes[network]) {
+    if (!Object.hasOwn(nodes, network) || !nodes[network]) {
       return res.status(404).json({ jsonrpc, id, error: 'Invalid network' });
     }
     return res.json({ jsonrpc, id, result: `0x${Number(network).toString(16)}` });

--- a/tests/e2e/network.test.ts
+++ b/tests/e2e/network.test.ts
@@ -89,9 +89,12 @@ describe('Network Endpoint E2E Tests', () => {
         expect(upstreamRequests).toBe(0);
       });
 
-      it('should proxy eth_chainId for a nonnumeric network', async () => {
+      it.each([
+        { network: 'sn', type: 'nonnumeric' },
+        { network: '0x1', type: 'coercible non-decimal' }
+      ])('should proxy eth_chainId for a $type network', async ({ network }) => {
         const response = await request(app)
-          .post('/sn')
+          .post(`/${network}`)
           .send({
             jsonrpc: '2.0',
             method: 'eth_chainId',
@@ -103,26 +106,6 @@ describe('Network Endpoint E2E Tests', () => {
         expect(response.body).toEqual({
           jsonrpc: '2.0',
           id: 2,
-          result: 'upstream-chain-id'
-        });
-        expect(response.body.result).not.toBe('0xNaN');
-        expect(upstreamRequests).toBe(1);
-      });
-
-      it('should proxy eth_chainId for a coercible non-decimal network', async () => {
-        const response = await request(app)
-          .post('/0x1')
-          .send({
-            jsonrpc: '2.0',
-            method: 'eth_chainId',
-            params: [],
-            id: 3
-          })
-          .expect(200);
-
-        expect(response.body).toEqual({
-          jsonrpc: '2.0',
-          id: 3,
           result: 'upstream-chain-id'
         });
         expect(upstreamRequests).toBe(1);
@@ -186,23 +169,26 @@ describe('Network Endpoint E2E Tests', () => {
         });
       });
 
-      it('should return 404 for an unknown nonnumeric network', async () => {
-        const response = await request(app)
-          .post('/doesnotexist')
-          .send({
-            jsonrpc: '2.0',
-            method: 'eth_chainId',
-            params: [],
-            id: 2
-          })
-          .expect(404);
+      it.each(['doesnotexist', '__proto__'])(
+        'should return 404 for unknown nonnumeric network %s',
+        async network => {
+          const response = await request(app)
+            .post(`/${network}`)
+            .send({
+              jsonrpc: '2.0',
+              method: 'eth_chainId',
+              params: [],
+              id: 2
+            })
+            .expect(404);
 
-        expect(response.body).toEqual({
-          jsonrpc: '2.0',
-          id: 2,
-          error: 'Invalid network'
-        });
-      });
+          expect(response.body).toEqual({
+            jsonrpc: '2.0',
+            id: 2,
+            error: 'Invalid network'
+          });
+        }
+      );
     });
 
     describe('JSON-RPC Errors', () => {

--- a/tests/e2e/network.test.ts
+++ b/tests/e2e/network.test.ts
@@ -2,7 +2,7 @@ import { Server } from 'http';
 import { AddressInfo } from 'net';
 import express from 'express';
 import request from 'supertest';
-import { nodes } from '../../src/helpers/nodes';
+import { nodes, stop } from '../../src/helpers/nodes';
 import rpc from '../../src/rpc';
 
 describe('Network Endpoint E2E Tests', () => {
@@ -21,6 +21,7 @@ describe('Network Endpoint E2E Tests', () => {
     let upstreamRequests = 0;
 
     beforeAll(async () => {
+      stop();
       const upstreamApp = express();
       upstreamApp.use(express.json());
       upstreamApp.post('/', (req, res) => {

--- a/tests/e2e/network.test.ts
+++ b/tests/e2e/network.test.ts
@@ -1,5 +1,8 @@
+import { Server } from 'http';
+import { AddressInfo } from 'net';
 import express from 'express';
 import request from 'supertest';
+import { nodes } from '../../src/helpers/nodes';
 import rpc from '../../src/rpc';
 
 describe('Network Endpoint E2E Tests', () => {
@@ -12,8 +15,53 @@ describe('Network Endpoint E2E Tests', () => {
   });
 
   describe('Cached Methods', () => {
+    let configuredNodes: Record<string, string>;
+    let originalNodes: Record<string, string | undefined>;
+    let upstream: Server;
+    let upstreamRequests = 0;
+
+    beforeAll(async () => {
+      const upstreamApp = express();
+      upstreamApp.use(express.json());
+      upstreamApp.post('/', (req, res) => {
+        upstreamRequests += 1;
+        res.json({ jsonrpc: req.body.jsonrpc, id: req.body.id, result: 'upstream-chain-id' });
+      });
+      upstream = await new Promise(resolve => {
+        const server = upstreamApp.listen(0, '127.0.0.1', () => resolve(server));
+      });
+      const { port } = upstream.address() as AddressInfo;
+      const upstreamUrl = `http://127.0.0.1:${port}`;
+      configuredNodes = nodes as Record<string, string>;
+      originalNodes = {
+        '1': configuredNodes['1'],
+        sn: configuredNodes.sn,
+        '0x1': configuredNodes['0x1']
+      };
+      configuredNodes['1'] = upstreamUrl;
+      configuredNodes.sn = upstreamUrl;
+      configuredNodes['0x1'] = upstreamUrl;
+    });
+
+    beforeEach(() => {
+      upstreamRequests = 0;
+    });
+
+    afterAll(async () => {
+      for (const [network, url] of Object.entries(originalNodes)) {
+        if (url === undefined) {
+          delete configuredNodes[network];
+        } else {
+          configuredNodes[network] = url;
+        }
+      }
+      await new Promise<void>((resolve, reject) => {
+        upstream.close(error => (error ? reject(error) : resolve()));
+      });
+    });
+
     describe('eth_chainId', () => {
-      it('should convert decimal network IDs to hex chainId', async () => {
+      it('should convert decimal network IDs to hex chainId without an upstream request', async () => {
         const testCases = [
           { network: '1', expected: '0x1' },
           { network: '10', expected: '0xa' },
@@ -38,6 +86,46 @@ describe('Network Endpoint E2E Tests', () => {
             result: testCase.expected
           });
         }
+        expect(upstreamRequests).toBe(0);
+      });
+
+      it('should proxy eth_chainId for a nonnumeric network', async () => {
+        const response = await request(app)
+          .post('/sn')
+          .send({
+            jsonrpc: '2.0',
+            method: 'eth_chainId',
+            params: [],
+            id: 2
+          })
+          .expect(200);
+
+        expect(response.body).toEqual({
+          jsonrpc: '2.0',
+          id: 2,
+          result: 'upstream-chain-id'
+        });
+        expect(response.body.result).not.toBe('0xNaN');
+        expect(upstreamRequests).toBe(1);
+      });
+
+      it('should proxy eth_chainId for a coercible non-decimal network', async () => {
+        const response = await request(app)
+          .post('/0x1')
+          .send({
+            jsonrpc: '2.0',
+            method: 'eth_chainId',
+            params: [],
+            id: 3
+          })
+          .expect(200);
+
+        expect(response.body).toEqual({
+          jsonrpc: '2.0',
+          id: 3,
+          result: 'upstream-chain-id'
+        });
+        expect(upstreamRequests).toBe(1);
       });
     });
   });
@@ -94,6 +182,24 @@ describe('Network Endpoint E2E Tests', () => {
         expect(response.body).toEqual({
           jsonrpc: '2.0',
           id: 1,
+          error: 'Invalid network'
+        });
+      });
+
+      it('should return 404 for an unknown nonnumeric network', async () => {
+        const response = await request(app)
+          .post('/doesnotexist')
+          .send({
+            jsonrpc: '2.0',
+            method: 'eth_chainId',
+            params: [],
+            id: 2
+          })
+          .expect(404);
+
+        expect(response.body).toEqual({
+          jsonrpc: '2.0',
+          id: 2,
           error: 'Invalid network'
         });
       });


### PR DESCRIPTION
## Summary

Only intercept `eth_chainId` when the route network is an exact decimal string. Configured non-decimal networks now continue through the normal upstream proxy, and network lookup accepts only configured own keys so unknown routes consistently return 404.

Closes #553

## Ordering

This should merge before #550 because both change request preprocessing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)