### PR TITLE
fix: don't cache block.number_gte queries forever

### DIFF
--- a/src/middlewares/processGraphql.test.ts
+++ b/src/middlewares/processGraphql.test.ts
@@ -1,0 +1,163 @@
+import { NextFunction, Request, Response } from 'express';
+import { get, set } from '../helpers/aws';
+import { fetchWithKeepAlive } from '../helpers/utils';
+
+jest.mock('../helpers/aws', () => ({
+  get: jest.fn(),
+  set: jest.fn()
+}));
+
+jest.mock('../helpers/utils', () => ({
+  ...jest.requireActual('../helpers/utils'),
+  fetchWithKeepAlive: jest.fn()
+}));
+
+const mockGet = jest.mocked(get);
+const mockSet = jest.mocked(set);
+const mockFetchWithKeepAlive = jest.mocked(fetchWithKeepAlive);
+const cachedResponses = new Map<string, any>();
+const upstreamResponse = { data: { items: [] } };
+const awsRegion = process.env.AWS_REGION;
+
+let processGraphql: (req: Request, res: Response, next: NextFunction) => Promise<void | Response>;
+
+function response() {
+  return {
+    ok: true,
+    text: async () => JSON.stringify(upstreamResponse)
+  } as any;
+}
+
+async function execute(query: string) {
+  const json = jest.fn();
+  const next = jest.fn();
+  const req = {
+    body: { query },
+    _subgraph_url: { url: 'https://example.com/graphql' }
+  } as unknown as Request;
+  const res = { json } as unknown as Response;
+
+  await processGraphql(req, res, next as NextFunction);
+
+  expect(next).not.toHaveBeenCalled();
+  expect(json).toHaveBeenCalledWith(upstreamResponse);
+}
+
+async function expectNoPersistentCache(query: string) {
+  await execute(query);
+  await execute(query);
+  expect(mockFetchWithKeepAlive).toHaveBeenCalledTimes(2);
+  expect(mockGet).not.toHaveBeenCalled();
+  expect(mockSet).not.toHaveBeenCalled();
+}
+
+beforeAll(async () => {
+  process.env.AWS_REGION = 'test-region';
+  processGraphql = (await import('./processGraphql')).default;
+});
+
+afterAll(() => {
+  if (awsRegion === undefined) {
+    delete process.env.AWS_REGION;
+  } else {
+    process.env.AWS_REGION = awsRegion;
+  }
+});
+
+beforeEach(() => {
+  cachedResponses.clear();
+  jest.clearAllMocks();
+  mockGet.mockImplementation(async key => cachedResponses.get(key) ?? false);
+  mockSet.mockImplementation(async (key, value) => {
+    cachedResponses.set(key, value);
+    return {} as any;
+  });
+  mockFetchWithKeepAlive.mockResolvedValue(response());
+});
+
+describe('processGraphql caching', () => {
+  it('caches queries pinned to an inline block number or hash', async () => {
+    const queries = [
+      '{ items(block: { number: 123 }) { id } }',
+      '{ items(block: { hash: "0x123" }) { id } }'
+    ];
+
+    for (const query of queries) {
+      await execute(query);
+      await execute(query);
+    }
+
+    expect(mockFetchWithKeepAlive).toHaveBeenCalledTimes(2);
+    expect(mockSet).toHaveBeenCalledTimes(2);
+  });
+
+  it('bypasses persistent caching for block number_gte while deduplicating in-flight requests', async () => {
+    const query = '{ items(block: { number_gte: 123 }) { id } }';
+
+    await expectNoPersistentCache(query);
+
+    let resolveFetch: ((value: any) => void) | undefined;
+    mockFetchWithKeepAlive.mockImplementationOnce(
+      () =>
+        new Promise(resolve => {
+          resolveFetch = resolve;
+        })
+    );
+
+    const firstRequest = execute(query);
+    const secondRequest = execute(query);
+
+    expect(mockFetchWithKeepAlive).toHaveBeenCalledTimes(3);
+    resolveFetch?.(response());
+    await Promise.all([firstRequest, secondRequest]);
+
+    expect(mockFetchWithKeepAlive).toHaveBeenCalledTimes(3);
+  });
+
+  it('uses an operation definition that follows a fragment definition', async () => {
+    const query = `
+      fragment ItemFields on Item {
+        id
+      }
+      query Items {
+        items(block: { number: 123 }) {
+          ...ItemFields
+        }
+      }
+    `;
+
+    await execute(query);
+    await execute(query);
+
+    expect(mockFetchWithKeepAlive).toHaveBeenCalledTimes(1);
+    expect(mockSet).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    [
+      'a fragment spread',
+      `
+        query Items {
+          items(block: { number: 123 }) { id }
+          ...MoreItems
+        }
+        fragment MoreItems on Query {
+          moreItems(block: { number: 123 }) { id }
+        }
+      `
+    ],
+    [
+      'an inline fragment',
+      `
+        query Items {
+          items(block: { number: 123 }) { id }
+          ... on Query {
+            moreItems(block: { number: 123 }) { id }
+          }
+        }
+      `
+    ]
+  ])('does not persist documents with %s', async (_selection, query) => {
+    await expectNoPersistentCache(query);
+  });
+});

--- a/src/middlewares/processGraphql.test.ts
+++ b/src/middlewares/processGraphql.test.ts
@@ -28,11 +28,11 @@ function response() {
   } as any;
 }
 
-async function execute(query: string) {
+async function execute(query: string, variables: Record<string, unknown> = {}) {
   const json = jest.fn();
   const next = jest.fn();
   const req = {
-    body: { query },
+    body: { query, variables },
     _subgraph_url: { url: 'https://example.com/graphql' }
   } as unknown as Request;
   const res = { json } as unknown as Response;
@@ -43,9 +43,9 @@ async function execute(query: string) {
   expect(json).toHaveBeenCalledWith(upstreamResponse);
 }
 
-async function expectNoPersistentCache(query: string) {
-  await execute(query);
-  await execute(query);
+async function expectNoPersistentCache(query: string, variables: Record<string, unknown> = {}) {
+  await execute(query, variables);
+  await execute(query, variables);
   expect(mockFetchWithKeepAlive).toHaveBeenCalledTimes(2);
   expect(mockGet).not.toHaveBeenCalled();
   expect(mockSet).not.toHaveBeenCalled();
@@ -89,6 +89,70 @@ describe('processGraphql caching', () => {
 
     expect(mockFetchWithKeepAlive).toHaveBeenCalledTimes(2);
     expect(mockSet).toHaveBeenCalledTimes(2);
+  });
+
+  it('caches queries pinned by block variables', async () => {
+    const query = 'query Items($block: Block_height) { items(block: $block) { id } }';
+    const variableSets = [{ block: { number: 123 } }, { block: { hash: '0x123' } }];
+
+    for (const variables of variableSets) {
+      await execute(query, variables);
+      await execute(query, variables);
+    }
+
+    expect(mockFetchWithKeepAlive).toHaveBeenCalledTimes(2);
+    expect(mockSet).toHaveBeenCalledTimes(2);
+  });
+
+  it('caches queries pinned by variables inside block objects', async () => {
+    const query = 'query Items($number: Int) { items(block: { number: $number }) { id } }';
+    const variables = { number: 123 };
+
+    await execute(query, variables);
+    await execute(query, variables);
+
+    expect(mockFetchWithKeepAlive).toHaveBeenCalledTimes(1);
+    expect(mockSet).toHaveBeenCalledTimes(1);
+  });
+
+  it('bypasses persistent caching when an inline block pin variable is unresolved', async () => {
+    const query = `
+      query Items($number: Int, $minimum: Int!) {
+        items(block: { number: $number, number_gte: $minimum }) { id }
+      }
+    `;
+
+    await expectNoPersistentCache(query, { minimum: 123 });
+  });
+
+  it('ignores inherited names when resolving inline block variables', async () => {
+    const query = `
+      query Items($toString: Int, $minimum: Int!) {
+        items(block: { number: $toString, number_gte: $minimum }) { id }
+      }
+    `;
+
+    await expectNoPersistentCache(query, { minimum: 123 });
+  });
+
+  it('bypasses persistent caching for unpinned block variables', async () => {
+    const query = 'query Items($block: Block_height) { items(block: $block) { id } }';
+    const variableSets = [
+      { block: { number_gte: 123 } },
+      { block: { number: null } },
+      { block: { hash: null } },
+      { block: null },
+      {}
+    ];
+
+    for (const variables of variableSets) {
+      await execute(query, variables);
+      await execute(query, variables);
+    }
+
+    expect(mockFetchWithKeepAlive).toHaveBeenCalledTimes(variableSets.length * 2);
+    expect(mockGet).not.toHaveBeenCalled();
+    expect(mockSet).not.toHaveBeenCalled();
   });
 
   it('bypasses persistent caching for block number_gte while deduplicating in-flight requests', async () => {

--- a/src/middlewares/processGraphql.ts
+++ b/src/middlewares/processGraphql.ts
@@ -124,7 +124,7 @@ export default async function processGraphql(req: Request, res: Response, next: 
     operation.selectionSet.selections.every(
       selection =>
         selection.kind === Kind.FIELD &&
-        (selection.arguments ?? []).some(
+        selection.arguments.some(
           argument => argument.name.value === 'block' && isPinnedBlock(argument.value)
         )
     );

--- a/src/middlewares/processGraphql.ts
+++ b/src/middlewares/processGraphql.ts
@@ -97,6 +97,27 @@ export default async function processGraphql(req: Request, res: Response, next: 
   const operation = parsedQuery.definitions.find(
     definition => definition.kind === Kind.OPERATION_DEFINITION
   );
+  const getVariable = name =>
+    variables !== null && typeof variables === 'object' && Object.hasOwn(variables, name)
+      ? variables[name]
+      : undefined;
+  const hasValue = value =>
+    value.kind === Kind.VARIABLE ? getVariable(value.name.value) != null : value.kind !== Kind.NULL;
+  const isPinnedBlock = value => {
+    if (value.kind === Kind.VARIABLE) {
+      const block = getVariable(value.name.value);
+      return (
+        block !== null && typeof block === 'object' && (block.number != null || block.hash != null)
+      );
+    }
+    return (
+      value.kind === Kind.OBJECT &&
+      value.fields.some(
+        field =>
+          (field.name.value === 'number' || field.name.value === 'hash') && hasValue(field.value)
+      )
+    );
+  };
   const shouldCache =
     isCacheConfigured &&
     !!operation &&
@@ -104,12 +125,7 @@ export default async function processGraphql(req: Request, res: Response, next: 
       selection =>
         selection.kind === Kind.FIELD &&
         (selection.arguments ?? []).some(
-          argument =>
-            argument.name.value === 'block' &&
-            argument.value.kind === Kind.OBJECT &&
-            argument.value.fields.some(
-              field => field.name.value === 'number' || field.name.value === 'hash'
-            )
+          argument => argument.name.value === 'block' && isPinnedBlock(argument.value)
         )
     );
   try {

--- a/src/middlewares/processGraphql.ts
+++ b/src/middlewares/processGraphql.ts
@@ -1,6 +1,6 @@
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import { NextFunction, Request, Response } from 'express';
-import { parse, print } from 'graphql';
+import { Kind, parse, print } from 'graphql';
 import { REQUEST_TIMEOUT } from '../constants';
 import { SubgraphError } from '../errors/SubgraphError';
 import { get, set } from '../helpers/aws';
@@ -94,10 +94,23 @@ export default async function processGraphql(req: Request, res: Response, next: 
       ? sha256(`${subgraphUrl}:${normalizedQuery}:${JSON.stringify(variables)}`)
       : sha256(`${subgraphUrl}:${normalizedQuery}`);
 
+  const operation = parsedQuery.definitions.find(
+    definition => definition.kind === Kind.OPERATION_DEFINITION
+  );
   const shouldCache =
     isCacheConfigured &&
-    parsedQuery.definitions[0].selectionSet.selections.every(selection =>
-      selection.arguments.some(argument => argument.name.value === 'block')
+    !!operation &&
+    operation.selectionSet.selections.every(
+      selection =>
+        selection.kind === Kind.FIELD &&
+        (selection.arguments ?? []).some(
+          argument =>
+            argument.name.value === 'block' &&
+            argument.value.kind === Kind.OBJECT &&
+            argument.value.fields.some(
+              field => field.name.value === 'number' || field.name.value === 'hash'
+            )
+        )
     );
   try {
     const result: any = await serve(cacheKey, getData, [


### PR DESCRIPTION
## Problem

Queries using `block.number_gte` have latest-block semantics, but brovider treated every `block` argument as immutable and stored the response in S3 without expiry. Cache inspection also assumed the first document definition and every selection were fields, so valid fragment layouts could bypass caching or throw.

## Change

- Persist responses only when every top-level operation field has a `block` pinned by `number` or `hash`, either inline or resolved from request variables.
- Treat unresolved, null, range-only, and non-field selections as uncacheable while still forwarding them.
- Find the operation definition regardless of document order.
- Keep request-level in-flight deduplication independent from persistent caching.
- Cover pinned and range blocks, variable resolution, definition ordering, fragment spreads, and inline fragments at the middleware boundary.

Closes #552

🤖 Generated with [Claude Code](https://claude.com/claude-code)
