### PR TITLE
feat: accept JSON-RPC batch requests

### DIFF
--- a/src/middlewares/setNode.ts
+++ b/src/middlewares/setNode.ts
@@ -13,12 +13,34 @@ const NODE_HEADERS: Record<string, Record<string, string>> = {
 
 export default function setNode(req: Request, res: Response, next: NextFunction) {
   const network = req.params[0];
-  const body = req.body || {};
-  const { jsonrpc, id } = body;
+  const body = req.body;
+  const requests = Array.isArray(body) ? body : [body];
+  const isBatch = Array.isArray(body);
+  const id =
+    !isBatch &&
+    body &&
+    typeof body === 'object' &&
+    (typeof body.id === 'string' || typeof body.id === 'number' || body.id === null)
+      ? body.id
+      : null;
+  const jsonrpc = isBatch ? '2.0' : body?.jsonrpc;
   const url = Object.hasOwn(nodes, network) ? nodes[network] : undefined;
 
-  if (!req.body || !jsonrpc) {
-    return res.status(400).json({ error: 'Invalid request' });
+  if (
+    requests.length === 0 ||
+    requests.some(
+      request =>
+        !request ||
+        typeof request !== 'object' ||
+        Array.isArray(request) ||
+        request.jsonrpc !== '2.0'
+    )
+  ) {
+    return res.status(400).json({
+      jsonrpc: '2.0',
+      id,
+      error: { code: -32600, message: 'Invalid Request' }
+    });
   }
 
   if (!url) {

--- a/src/middlewares/setNode.ts
+++ b/src/middlewares/setNode.ts
@@ -14,8 +14,8 @@ const NODE_HEADERS: Record<string, Record<string, string>> = {
 export default function setNode(req: Request, res: Response, next: NextFunction) {
   const network = req.params[0];
   const body = req.body;
-  const requests = Array.isArray(body) ? body : [body];
   const isBatch = Array.isArray(body);
+  const requests = isBatch ? body : [body];
   const id =
     !isBatch &&
     body &&

--- a/src/middlewares/withCachedEthChain.ts
+++ b/src/middlewares/withCachedEthChain.ts
@@ -3,9 +3,20 @@ import { nodes } from '../helpers/nodes';
 
 export default function withCachedEthChain(req: Request, res: Response, next: NextFunction) {
   const network = req.params[0];
-  const { method, jsonrpc, id } = req.body || {};
+  const body = req.body || {};
+  const { method, jsonrpc, id, params } = body;
+  const hasValidId =
+    Object.hasOwn(body, 'id') && (typeof id === 'string' || typeof id === 'number' || id === null);
+  const hasValidParams =
+    !Object.hasOwn(body, 'params') || (Array.isArray(params) && params.length === 0);
 
-  if (jsonrpc === '2.0' && method === 'eth_chainId' && /^\d+$/.test(network)) {
+  if (
+    jsonrpc === '2.0' &&
+    method === 'eth_chainId' &&
+    hasValidId &&
+    hasValidParams &&
+    /^\d+$/.test(network)
+  ) {
     // Check if network exists before returning cached response
     if (!Object.hasOwn(nodes, network) || !nodes[network]) {
       return res.status(404).json({ jsonrpc, id, error: 'Invalid network' });

--- a/src/middlewares/withCachedEthChain.ts
+++ b/src/middlewares/withCachedEthChain.ts
@@ -5,7 +5,7 @@ export default function withCachedEthChain(req: Request, res: Response, next: Ne
   const network = req.params[0];
   const { method, jsonrpc, id } = req.body || {};
 
-  if (method === 'eth_chainId' && /^\d+$/.test(network)) {
+  if (jsonrpc === '2.0' && method === 'eth_chainId' && /^\d+$/.test(network)) {
     // Check if network exists before returning cached response
     if (!Object.hasOwn(nodes, network) || !nodes[network]) {
       return res.status(404).json({ jsonrpc, id, error: 'Invalid network' });

--- a/tests/e2e/network.test.ts
+++ b/tests/e2e/network.test.ts
@@ -291,12 +291,12 @@ describe('Network Endpoint E2E Tests', () => {
         });
       });
 
-      it('should preserve the ID of an invalid single request', async () => {
+      it('should preserve the ID of an invalid single chain ID request', async () => {
         const response = await request(app)
           .post('/1')
           .send({
             jsonrpc: '1.0',
-            method: 'eth_blockNumber',
+            method: 'eth_chainId',
             params: [],
             id: 'invalid-version'
           })

--- a/tests/e2e/network.test.ts
+++ b/tests/e2e/network.test.ts
@@ -19,7 +19,7 @@ describe('Network Endpoint E2E Tests', () => {
     let originalNodes: Record<string, string | undefined>;
     let upstream: Server;
     let upstreamRequests = 0;
-    let upstreamBody: unknown;
+    let upstreamBodies: unknown[] = [];
 
     beforeAll(async () => {
       stop();
@@ -27,8 +27,24 @@ describe('Network Endpoint E2E Tests', () => {
       upstreamApp.use(express.json());
       upstreamApp.post('/', (req, res) => {
         upstreamRequests += 1;
-        upstreamBody = req.body;
-        res.json({ jsonrpc: req.body.jsonrpc, id: req.body.id, result: 'upstream-chain-id' });
+        upstreamBodies.push(req.body);
+
+        const getResponse = (body: { jsonrpc: unknown; id: unknown; method: string }) => ({
+          jsonrpc: body.jsonrpc,
+          id: body.id,
+          result: body.method === 'eth_chainId' ? 'upstream-chain-id' : `upstream-${body.method}`
+        });
+
+        if (Array.isArray(req.body)) {
+          return res.json(
+            req.body
+              .filter(item => Object.hasOwn(item, 'id'))
+              .map(getResponse)
+              .reverse()
+          );
+        }
+
+        return res.json(getResponse(req.body));
       });
       upstream = await new Promise(resolve => {
         const server = upstreamApp.listen(0, '127.0.0.1', () => resolve(server));
@@ -50,7 +66,7 @@ describe('Network Endpoint E2E Tests', () => {
 
     beforeEach(() => {
       upstreamRequests = 0;
-      upstreamBody = undefined;
+      upstreamBodies = [];
     });
 
     afterAll(async () => {
@@ -113,7 +129,188 @@ describe('Network Endpoint E2E Tests', () => {
           result: 'upstream-chain-id'
         });
         expect(upstreamRequests).toBe(1);
-        expect(upstreamBody).toEqual(body);
+        expect(upstreamBodies).toEqual([body]);
+      });
+    });
+
+    describe('Batch Requests', () => {
+      it('should forward batch arrays unchanged and correlate reordered responses by ID', async () => {
+        const body = [
+          {
+            jsonrpc: '2.0',
+            method: 'eth_blockNumber',
+            params: [],
+            id: 'block'
+          },
+          {
+            jsonrpc: '2.0',
+            method: 'eth_getBalance',
+            params: ['0x0000000000000000000000000000000000000000', 'latest'],
+            id: 'balance'
+          }
+        ];
+
+        const response = await request(app).post('/1').send(body).expect(200);
+
+        expect(upstreamBodies).toEqual([body]);
+        expect(response.body.map((item: { id: unknown }) => item.id)).toEqual(['balance', 'block']);
+        expect(
+          Object.fromEntries(
+            response.body.map((item: { id: string; result: unknown }) => [item.id, item.result])
+          )
+        ).toEqual({
+          block: 'upstream-eth_blockNumber',
+          balance: 'upstream-eth_getBalance'
+        });
+      });
+
+      it('should proxy batch eth_chainId instead of answering it locally', async () => {
+        const body = [
+          {
+            jsonrpc: '2.0',
+            method: 'eth_chainId',
+            params: [],
+            id: 'chain'
+          },
+          {
+            jsonrpc: '2.0',
+            method: 'eth_blockNumber',
+            params: [],
+            id: 'block'
+          }
+        ];
+
+        const response = await request(app).post('/1').send(body).expect(200);
+        const responses = Object.fromEntries(
+          response.body.map((item: { id: string; result: unknown }) => [item.id, item.result])
+        );
+
+        expect(upstreamRequests).toBe(1);
+        expect(upstreamBodies).toEqual([body]);
+        expect(responses.chain).toBe('upstream-chain-id');
+      });
+
+      it('should allow notification members without an ID', async () => {
+        const body = [
+          {
+            jsonrpc: '2.0',
+            method: 'eth_blockNumber',
+            params: []
+          },
+          {
+            jsonrpc: '2.0',
+            method: 'eth_getBalance',
+            params: ['0x0000000000000000000000000000000000000000', 'latest'],
+            id: 7
+          }
+        ];
+
+        const response = await request(app).post('/1').send(body).expect(200);
+
+        expect(upstreamBodies).toEqual([body]);
+        expect(response.body).toEqual([
+          {
+            jsonrpc: '2.0',
+            id: 7,
+            result: 'upstream-eth_getBalance'
+          }
+        ]);
+      });
+    });
+
+    it('should keep forwarding valid single requests unchanged', async () => {
+      const body = {
+        jsonrpc: '2.0',
+        method: 'eth_blockNumber',
+        params: [],
+        id: 'single'
+      };
+
+      const response = await request(app).post('/1').send(body).expect(200);
+
+      expect(upstreamBodies).toEqual([body]);
+      expect(response.body).toEqual({
+        jsonrpc: '2.0',
+        id: 'single',
+        result: 'upstream-eth_blockNumber'
+      });
+    });
+
+    describe('Request Validation Errors', () => {
+      it('should return a JSON-RPC error for a missing request body', async () => {
+        const response = await request(app).post('/1').expect(400);
+
+        expect(upstreamRequests).toBe(0);
+        expect(response.body).toEqual({
+          jsonrpc: '2.0',
+          id: null,
+          error: {
+            code: -32600,
+            message: 'Invalid Request'
+          }
+        });
+      });
+
+      it('should reject an empty batch', async () => {
+        const response = await request(app).post('/1').send([]).expect(400);
+
+        expect(upstreamRequests).toBe(0);
+        expect(response.body).toEqual({
+          jsonrpc: '2.0',
+          id: null,
+          error: {
+            code: -32600,
+            message: 'Invalid Request'
+          }
+        });
+      });
+
+      it.each([
+        {
+          type: 'missing jsonrpc',
+          invalidRequest: { method: 'eth_blockNumber', params: [], id: 2 }
+        },
+        {
+          type: 'invalid jsonrpc',
+          invalidRequest: { jsonrpc: '1.0', method: 'eth_blockNumber', params: [], id: 2 }
+        }
+      ])('should reject a batch member with $type', async ({ invalidRequest }) => {
+        const response = await request(app)
+          .post('/1')
+          .send([{ jsonrpc: '2.0', method: 'eth_blockNumber', params: [], id: 1 }, invalidRequest])
+          .expect(400);
+
+        expect(upstreamRequests).toBe(0);
+        expect(response.body).toEqual({
+          jsonrpc: '2.0',
+          id: null,
+          error: {
+            code: -32600,
+            message: 'Invalid Request'
+          }
+        });
+      });
+
+      it('should preserve the ID of an invalid single request', async () => {
+        const response = await request(app)
+          .post('/1')
+          .send({
+            jsonrpc: '1.0',
+            method: 'eth_blockNumber',
+            params: [],
+            id: 'invalid-version'
+          })
+          .expect(400);
+
+        expect(upstreamRequests).toBe(0);
+        expect(response.body).toEqual({
+          jsonrpc: '2.0',
+          id: 'invalid-version',
+          error: {
+            code: -32600,
+            message: 'Invalid Request'
+          }
+        });
       });
     });
   });
@@ -140,14 +337,6 @@ describe('Network Endpoint E2E Tests', () => {
 
   describe('Error Handling', () => {
     describe('Request Validation Errors', () => {
-      it('should return 400 for missing request body', async () => {
-        const response = await request(app).post('/1').expect(400);
-
-        expect(response.body).toEqual({
-          error: 'Invalid request'
-        });
-      });
-
       it('should return 400 for malformed JSON', async () => {
         await request(app)
           .post('/1')

--- a/tests/e2e/network.test.ts
+++ b/tests/e2e/network.test.ts
@@ -15,10 +15,10 @@ describe('Network Endpoint E2E Tests', () => {
   });
 
   describe('Cached Methods', () => {
+    const configuredNetworks = ['1', '10', 'sn', '0x1'];
     let configuredNodes: Record<string, string>;
     let originalNodes: Record<string, string | undefined>;
     let upstream: Server;
-    let upstreamRequests = 0;
     let upstreamBodies: unknown[] = [];
 
     beforeAll(async () => {
@@ -26,7 +26,6 @@ describe('Network Endpoint E2E Tests', () => {
       const upstreamApp = express();
       upstreamApp.use(express.json());
       upstreamApp.post('/', (req, res) => {
-        upstreamRequests += 1;
         upstreamBodies.push(req.body);
 
         const getResponse = (body: { jsonrpc: unknown; id: unknown; method: string }) => ({
@@ -56,20 +55,15 @@ describe('Network Endpoint E2E Tests', () => {
       const { port } = upstream.address() as AddressInfo;
       const upstreamUrl = `http://127.0.0.1:${port}`;
       configuredNodes = nodes as Record<string, string>;
-      originalNodes = {
-        '1': configuredNodes['1'],
-        '10': configuredNodes['10'],
-        sn: configuredNodes.sn,
-        '0x1': configuredNodes['0x1']
-      };
-      configuredNodes['1'] = upstreamUrl;
-      configuredNodes['10'] = upstreamUrl;
-      configuredNodes.sn = upstreamUrl;
-      configuredNodes['0x1'] = upstreamUrl;
+      originalNodes = Object.fromEntries(
+        configuredNetworks.map(network => [network, configuredNodes[network]])
+      );
+      for (const network of configuredNetworks) {
+        configuredNodes[network] = upstreamUrl;
+      }
     });
 
     beforeEach(() => {
-      upstreamRequests = 0;
       upstreamBodies = [];
     });
 
@@ -112,7 +106,7 @@ describe('Network Endpoint E2E Tests', () => {
             result: testCase.expected
           });
         }
-        expect(upstreamRequests).toBe(0);
+        expect(upstreamBodies).toHaveLength(0);
       });
 
       it.each([
@@ -132,7 +126,7 @@ describe('Network Endpoint E2E Tests', () => {
           id: 2,
           result: 'upstream-chain-id'
         });
-        expect(upstreamRequests).toBe(1);
+        expect(upstreamBodies).toHaveLength(1);
         expect(upstreamBodies).toEqual([body]);
       });
 
@@ -151,7 +145,7 @@ describe('Network Endpoint E2E Tests', () => {
           id: 3,
           result: '0x1'
         });
-        expect(upstreamRequests).toBe(0);
+        expect(upstreamBodies).toHaveLength(0);
       });
 
       it.each([
@@ -166,7 +160,7 @@ describe('Network Endpoint E2E Tests', () => {
       ])('should proxy a request with $type', async ({ body }) => {
         const response = await request(app).post('/1').send(body).expect(200);
 
-        expect(upstreamRequests).toBe(1);
+        expect(upstreamBodies).toHaveLength(1);
         expect(upstreamBodies).toEqual([body]);
         expect(response.body).toEqual({
           jsonrpc: '2.0',
@@ -184,7 +178,7 @@ describe('Network Endpoint E2E Tests', () => {
 
         await request(app).post('/1').send(body).expect(204);
 
-        expect(upstreamRequests).toBe(1);
+        expect(upstreamBodies).toHaveLength(1);
         expect(upstreamBodies).toEqual([body]);
       });
     });
@@ -241,7 +235,7 @@ describe('Network Endpoint E2E Tests', () => {
           response.body.map((item: { id: string; result: unknown }) => [item.id, item.result])
         );
 
-        expect(upstreamRequests).toBe(1);
+        expect(upstreamBodies).toHaveLength(1);
         expect(upstreamBodies).toEqual([body]);
         expect(responses.chain).toBe('upstream-chain-id');
       });
@@ -296,7 +290,7 @@ describe('Network Endpoint E2E Tests', () => {
       it('should return a JSON-RPC error for a missing request body', async () => {
         const response = await request(app).post('/1').expect(400);
 
-        expect(upstreamRequests).toBe(0);
+        expect(upstreamBodies).toHaveLength(0);
         expect(response.body).toEqual({
           jsonrpc: '2.0',
           id: null,
@@ -310,7 +304,7 @@ describe('Network Endpoint E2E Tests', () => {
       it('should reject an empty batch', async () => {
         const response = await request(app).post('/1').send([]).expect(400);
 
-        expect(upstreamRequests).toBe(0);
+        expect(upstreamBodies).toHaveLength(0);
         expect(response.body).toEqual({
           jsonrpc: '2.0',
           id: null,
@@ -336,7 +330,7 @@ describe('Network Endpoint E2E Tests', () => {
           .send([{ jsonrpc: '2.0', method: 'eth_blockNumber', params: [], id: 1 }, invalidRequest])
           .expect(400);
 
-        expect(upstreamRequests).toBe(0);
+        expect(upstreamBodies).toHaveLength(0);
         expect(response.body).toEqual({
           jsonrpc: '2.0',
           id: null,
@@ -358,7 +352,7 @@ describe('Network Endpoint E2E Tests', () => {
           })
           .expect(400);
 
-        expect(upstreamRequests).toBe(0);
+        expect(upstreamBodies).toHaveLength(0);
         expect(response.body).toEqual({
           jsonrpc: '2.0',
           id: 'invalid-version',

--- a/tests/e2e/network.test.ts
+++ b/tests/e2e/network.test.ts
@@ -130,6 +130,25 @@ describe('Network Endpoint E2E Tests', () => {
         expect(upstreamBodies).toEqual([body]);
       });
 
+      it('should proxy a valid request for a non-decimal network', async () => {
+        const body = {
+          jsonrpc: '2.0',
+          method: 'eth_chainId',
+          params: [],
+          id: 3
+        };
+
+        const response = await request(app).post('/sn').send(body).expect(200);
+
+        expect(response.body).toEqual({
+          jsonrpc: '2.0',
+          id: 3,
+          result: 'upstream-chain-id'
+        });
+        expect(upstreamBodies).toHaveLength(1);
+        expect(upstreamBodies).toEqual([body]);
+      });
+
       it('should answer a valid request without params locally', async () => {
         const response = await request(app)
           .post('/1')

--- a/tests/e2e/network.test.ts
+++ b/tests/e2e/network.test.ts
@@ -126,7 +126,6 @@ describe('Network Endpoint E2E Tests', () => {
           id: 2,
           result: 'upstream-chain-id'
         });
-        expect(upstreamBodies).toHaveLength(1);
         expect(upstreamBodies).toEqual([body]);
       });
 
@@ -145,7 +144,6 @@ describe('Network Endpoint E2E Tests', () => {
           id: 3,
           result: 'upstream-chain-id'
         });
-        expect(upstreamBodies).toHaveLength(1);
         expect(upstreamBodies).toEqual([body]);
       });
 
@@ -179,7 +177,6 @@ describe('Network Endpoint E2E Tests', () => {
       ])('should proxy a request with $type', async ({ body }) => {
         const response = await request(app).post('/1').send(body).expect(200);
 
-        expect(upstreamBodies).toHaveLength(1);
         expect(upstreamBodies).toEqual([body]);
         expect(response.body).toEqual({
           jsonrpc: '2.0',
@@ -197,7 +194,6 @@ describe('Network Endpoint E2E Tests', () => {
 
         await request(app).post('/1').send(body).expect(204);
 
-        expect(upstreamBodies).toHaveLength(1);
         expect(upstreamBodies).toEqual([body]);
       });
     });
@@ -254,7 +250,6 @@ describe('Network Endpoint E2E Tests', () => {
           response.body.map((item: { id: string; result: unknown }) => [item.id, item.result])
         );
 
-        expect(upstreamBodies).toHaveLength(1);
         expect(upstreamBodies).toEqual([body]);
         expect(responses.chain).toBe('upstream-chain-id');
       });

--- a/tests/e2e/network.test.ts
+++ b/tests/e2e/network.test.ts
@@ -44,6 +44,10 @@ describe('Network Endpoint E2E Tests', () => {
           );
         }
 
+        if (!Object.hasOwn(req.body, 'id')) {
+          return res.status(204).end();
+        }
+
         return res.json(getResponse(req.body));
       });
       upstream = await new Promise(resolve => {
@@ -128,6 +132,58 @@ describe('Network Endpoint E2E Tests', () => {
           id: 2,
           result: 'upstream-chain-id'
         });
+        expect(upstreamRequests).toBe(1);
+        expect(upstreamBodies).toEqual([body]);
+      });
+
+      it('should answer a valid request without params locally', async () => {
+        const response = await request(app)
+          .post('/1')
+          .send({
+            jsonrpc: '2.0',
+            method: 'eth_chainId',
+            id: 3
+          })
+          .expect(200);
+
+        expect(response.body).toEqual({
+          jsonrpc: '2.0',
+          id: 3,
+          result: '0x1'
+        });
+        expect(upstreamRequests).toBe(0);
+      });
+
+      it.each([
+        {
+          type: 'string params',
+          body: { jsonrpc: '2.0', method: 'eth_chainId', params: 'bad', id: 3 }
+        },
+        {
+          type: 'boolean ID',
+          body: { jsonrpc: '2.0', method: 'eth_chainId', params: [], id: false }
+        }
+      ])('should proxy a request with $type', async ({ body }) => {
+        const response = await request(app).post('/1').send(body).expect(200);
+
+        expect(upstreamRequests).toBe(1);
+        expect(upstreamBodies).toEqual([body]);
+        expect(response.body).toEqual({
+          jsonrpc: '2.0',
+          id: body.id,
+          result: 'upstream-chain-id'
+        });
+      });
+
+      it('should proxy a notification without returning a local response', async () => {
+        const body = {
+          jsonrpc: '2.0',
+          method: 'eth_chainId',
+          params: []
+        };
+
+        await request(app).post('/1').send(body).expect(204);
+
         expect(upstreamRequests).toBe(1);
         expect(upstreamBodies).toEqual([body]);
       });


### PR DESCRIPTION
## Summary

Accepts non-empty JSON-RPC batch envelopes and forwards them unchanged to configured nodes. Empty or malformed envelopes now receive a spec-shaped `-32600` response locally, while valid notifications and single requests keep their existing proxy behavior.

Local `eth_chainId` responses are limited to valid single requests so batches, notifications, and malformed requests retain upstream semantics.

Closes #550

🤖 Generated with [Claude Code](https://claude.com/claude-code)
