### PR TITLE
feat: cache and dedupe block-pinned deterministic RPC reads

### DIFF
--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -32,6 +32,12 @@ export const cacheHitCount = new client.Counter({
   labelNames: ['status']
 });
 
+export const rpcCacheCount = new client.Counter({
+  name: 'rpc_cache_count',
+  help: 'Number of hit/miss/bypass of the RPC cache layer',
+  labelNames: ['status']
+});
+
 export const requestDeduplicatorSize = new client.Gauge({
   name: 'request_deduplicator_size',
   help: 'Total number of items in the deduplicator queue'

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -1,8 +1,10 @@
 import { createHash } from 'crypto';
+import http from 'node:http';
 import https from 'node:https';
 import fetch, { RequestInit, Response } from 'node-fetch';
 
 const DEFAULT_FETCH_TIMEOUT = 30000;
+const httpAgent = new http.Agent({ keepAlive: true });
 const httpsAgent = new https.Agent({ keepAlive: true });
 
 export async function sleep(ms: number): Promise<void> {
@@ -28,7 +30,7 @@ export const fetchWithKeepAlive = async (
 
   try {
     const response = await fetch(uri, {
-      agent: httpsAgent,
+      agent: ({ protocol }) => (protocol === 'http:' ? httpAgent : httpsAgent),
       signal: controller.signal,
       ...fetchOptions
     });

--- a/src/middlewares/withRpcCache.ts
+++ b/src/middlewares/withRpcCache.ts
@@ -16,10 +16,11 @@ const BLOCK_PARAM_INDEX = new Map([
 const HEX_BLOCK = /^0x[0-9a-f]+$/i;
 const CONFIRMATIONS = 128;
 const HEAD_TTL = 10e3;
-const MAX_ENTRIES = 5000;
 const MAX_VALUE_SIZE = 100e3;
+const MAX_CACHE_SIZE = 64e6;
 
-const cache = new Map<string, any>();
+const cache = new Map<string, { value: any; size: number }>();
+let cacheSize = 0;
 const heads = new Map<string, { number: number | null; expiresAt: number }>();
 
 function pinnedBlock(body: any): number | undefined {
@@ -65,19 +66,26 @@ async function headOf(node: Node): Promise<number | null> {
 }
 
 function readCache(key: string) {
-  const value = cache.get(key);
-  if (value === undefined) return undefined;
+  const entry = cache.get(key);
+  if (entry === undefined) return undefined;
 
   cache.delete(key);
-  cache.set(key, value);
-  return value;
+  cache.set(key, entry);
+  return entry.value;
 }
 
 function writeCache(key: string, value: any) {
-  if (JSON.stringify(value).length > MAX_VALUE_SIZE) return;
+  const size = JSON.stringify(value).length;
+  if (size > MAX_VALUE_SIZE) return;
 
-  cache.set(key, value);
-  if (cache.size > MAX_ENTRIES) cache.delete(cache.keys().next().value as string);
+  cacheSize += size - (cache.get(key)?.size ?? 0);
+  cache.set(key, { value, size });
+
+  while (cacheSize > MAX_CACHE_SIZE && cache.size > 1) {
+    const [oldest, entry] = cache.entries().next().value as [string, { size: number }];
+    cache.delete(oldest);
+    cacheSize -= entry.size;
+  }
 }
 
 export default async function withRpcCache(req: Request, res: Response, next: NextFunction) {

--- a/src/middlewares/withRpcCache.ts
+++ b/src/middlewares/withRpcCache.ts
@@ -1,0 +1,116 @@
+import { NextFunction, Request, Response } from 'express';
+import { REQUEST_TIMEOUT } from '../constants';
+import { rpcCacheCount } from '../helpers/metrics';
+import serve from '../helpers/requestDeduplicator';
+import { fetchWithKeepAlive, sha256 } from '../helpers/utils';
+
+type Node = { url: string; network: string; headers: Record<string, string> };
+
+const BLOCK_PARAM_INDEX = new Map([
+  ['eth_call', 1],
+  ['eth_getBalance', 1],
+  ['eth_getCode', 1],
+  ['eth_getStorageAt', 2]
+]);
+
+const HEX_BLOCK = /^0x[0-9a-f]+$/i;
+const CONFIRMATIONS = 128;
+const HEAD_TTL = 10e3;
+const MAX_ENTRIES = 5000;
+const MAX_VALUE_SIZE = 100e3;
+
+const cache = new Map<string, any>();
+const heads = new Map<string, { number: number | null; expiresAt: number }>();
+
+function pinnedBlock(body: any): number | undefined {
+  const index = BLOCK_PARAM_INDEX.get(body?.method);
+  if (index === undefined || !Array.isArray(body.params)) return undefined;
+
+  const param = body.params[index];
+  if (typeof param !== 'string' || !HEX_BLOCK.test(param)) return undefined;
+
+  return parseInt(param, 16);
+}
+
+async function rpcCall(node: Node, body: any) {
+  const res = await fetchWithKeepAlive(node.url, {
+    method: 'POST',
+    headers: { Accept: 'application/json', 'Content-Type': 'application/json', ...node.headers },
+    timeout: REQUEST_TIMEOUT,
+    body: JSON.stringify(body)
+  });
+
+  return { status: res.status, body: await res.json() };
+}
+
+async function headOf(node: Node): Promise<number | null> {
+  const known = heads.get(node.network);
+  if (known && known.expiresAt > Date.now()) return known.number;
+
+  let number: number | null = null;
+  try {
+    const { body } = await serve(`${node.network}:eth_blockNumber`, rpcCall, [
+      node,
+      { jsonrpc: '2.0', id: 1, method: 'eth_blockNumber', params: [] }
+    ]);
+    if (typeof body?.result === 'string' && HEX_BLOCK.test(body.result)) {
+      number = parseInt(body.result, 16);
+    }
+  } catch (e: any) {
+    console.log('[withRpcCache] head lookup failed', node.network, e.message || e);
+  }
+
+  heads.set(node.network, { number, expiresAt: Date.now() + HEAD_TTL });
+  return number;
+}
+
+function readCache(key: string) {
+  const value = cache.get(key);
+  if (value === undefined) return undefined;
+
+  cache.delete(key);
+  cache.set(key, value);
+  return value;
+}
+
+function writeCache(key: string, value: any) {
+  if (JSON.stringify(value).length > MAX_VALUE_SIZE) return;
+
+  cache.set(key, value);
+  if (cache.size > MAX_ENTRIES) cache.delete(cache.keys().next().value as string);
+}
+
+export default async function withRpcCache(req: Request, res: Response, next: NextFunction) {
+  const node: Node = (req as any)._node;
+  const body = req.body;
+  const block = pinnedBlock(body);
+
+  if (block === undefined) {
+    rpcCacheCount.inc({ status: 'BYPASS' });
+    return next();
+  }
+
+  const key = sha256(`${node.network}:${body.method}:${JSON.stringify(body.params)}`);
+  const cached = readCache(key);
+  if (cached !== undefined) {
+    rpcCacheCount.inc({ status: 'HIT' });
+    return res.json({ jsonrpc: body.jsonrpc, id: body.id, result: cached });
+  }
+
+  rpcCacheCount.inc({ status: 'MISS' });
+  const [head, response] = await Promise.all([
+    headOf(node),
+    serve(key, rpcCall, [node, body]).catch(() => null)
+  ]);
+  if (!response) return next();
+
+  const payload = response.body;
+  const isEnvelope = !!payload && typeof payload === 'object' && !Array.isArray(payload);
+  const isFinal = head !== null && block <= head - CONFIRMATIONS;
+
+  if (isEnvelope && isFinal && payload.error == null && payload.result != null) {
+    writeCache(key, payload.result);
+  }
+
+  return res.status(response.status).json(isEnvelope ? { ...payload, id: body.id } : payload);
+}

--- a/src/middlewares/withRpcCache.ts
+++ b/src/middlewares/withRpcCache.ts
@@ -5,6 +5,7 @@ import serve from '../helpers/requestDeduplicator';
 import { fetchWithKeepAlive, sha256 } from '../helpers/utils';
 
 type Node = { url: string; network: string; headers: Record<string, string> };
+type Entry = { value: any; size: number; expiresAt: number };
 
 const BLOCK_PARAM_INDEX = new Map([
   ['eth_call', 1],
@@ -13,13 +14,29 @@ const BLOCK_PARAM_INDEX = new Map([
   ['eth_getStorageAt', 2]
 ]);
 
+const SKIPPED_HEADERS = new Set([
+  'connection',
+  'content-encoding',
+  'content-length',
+  'etag',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade'
+]);
+
 const HEX_BLOCK = /^0x[0-9a-f]+$/i;
 const CONFIRMATIONS = 128;
 const HEAD_TTL = 10e3;
+const ENTRY_TTL = 3600e3;
 const MAX_VALUE_SIZE = 100e3;
-const MAX_CACHE_SIZE = 64e6;
+const MAX_CACHE_SIZE = 16e6;
+const ENTRY_OVERHEAD = 128;
 
-const cache = new Map<string, { value: any; size: number }>();
+const cache = new Map<string, Entry>();
 let cacheSize = 0;
 const heads = new Map<string, { number: number | null; expiresAt: number }>();
 
@@ -41,7 +58,7 @@ async function rpcCall(node: Node, body: any) {
     body: JSON.stringify(body)
   });
 
-  return { status: res.status, body: await res.json() };
+  return { status: res.status, headers: res.headers.raw(), body: await res.json() };
 }
 
 async function headOf(node: Node): Promise<number | null> {
@@ -58,7 +75,7 @@ async function headOf(node: Node): Promise<number | null> {
       number = parseInt(body.result, 16);
     }
   } catch (e: any) {
-    console.log('[withRpcCache] head lookup failed', node.network, e.message || e);
+    console.log('[withRpcCache] head lookup failed', node.network, e?.errors?.[0]?.message ?? e);
   }
 
   heads.set(node.network, { number, expiresAt: Date.now() + HEAD_TTL });
@@ -70,19 +87,25 @@ function readCache(key: string) {
   if (entry === undefined) return undefined;
 
   cache.delete(key);
+  if (entry.expiresAt <= Date.now()) {
+    cacheSize -= entry.size;
+    return undefined;
+  }
+
   cache.set(key, entry);
   return entry.value;
 }
 
 function writeCache(key: string, value: any) {
-  const size = JSON.stringify(value).length;
-  if (size > MAX_VALUE_SIZE) return;
+  const chars = JSON.stringify(value).length;
+  if (cache.has(key) || chars > MAX_VALUE_SIZE) return;
 
-  cacheSize += size - (cache.get(key)?.size ?? 0);
-  cache.set(key, { value, size });
+  const size = 2 * (chars + key.length) + ENTRY_OVERHEAD;
+  cache.set(key, { value, size, expiresAt: Date.now() + ENTRY_TTL });
+  cacheSize += size;
 
   while (cacheSize > MAX_CACHE_SIZE && cache.size > 1) {
-    const [oldest, entry] = cache.entries().next().value as [string, { size: number }];
+    const [oldest, entry] = cache.entries().next().value as [string, Entry];
     cache.delete(oldest);
     cacheSize -= entry.size;
   }
@@ -98,27 +121,38 @@ export default async function withRpcCache(req: Request, res: Response, next: Ne
     return next();
   }
 
-  const key = sha256(`${node.network}:${body.method}:${JSON.stringify(body.params)}`);
+  const key = sha256(`${node.url}:${body.method}:${JSON.stringify(body.params)}`);
   const cached = readCache(key);
   if (cached !== undefined) {
     rpcCacheCount.inc({ status: 'HIT' });
-    return res.json({ jsonrpc: body.jsonrpc, id: body.id, result: cached });
+    return res.json({ jsonrpc: '2.0', id: body.id, result: cached });
   }
 
   rpcCacheCount.inc({ status: 'MISS' });
-  const [head, response] = await Promise.all([
-    headOf(node),
-    serve(key, rpcCall, [node, body]).catch(() => null)
-  ]);
-  if (!response) return next();
+  const pendingHead = headOf(node);
+
+  let response: { status: number; headers: Record<string, string[]>; body: any };
+  try {
+    response = await serve(key, rpcCall, [node, body]);
+  } catch (e) {
+    await pendingHead;
+    return res.status(502).json({
+      jsonrpc: '2.0',
+      id: body.id,
+      error: { code: -32603, message: 'Upstream request failed' }
+    });
+  }
+
+  for (const [name, values] of Object.entries(response.headers)) {
+    if (!SKIPPED_HEADERS.has(name)) res.setHeader(name, values);
+  }
 
   const payload = response.body;
   const isEnvelope = !!payload && typeof payload === 'object' && !Array.isArray(payload);
-  const isFinal = head !== null && block <= head - CONFIRMATIONS;
+  res.status(response.status).json(isEnvelope ? { ...payload, id: body.id } : payload);
 
-  if (isEnvelope && isFinal && payload.error == null && payload.result != null) {
-    writeCache(key, payload.result);
+  const head = await pendingHead;
+  if (isEnvelope && head !== null && block <= head - CONFIRMATIONS) {
+    if (payload.error == null && payload.result != null) writeCache(key, payload.result);
   }
-
-  return res.status(response.status).json(isEnvelope ? { ...payload, id: body.id } : payload);
 }

--- a/src/middlewares/withRpcCache.ts
+++ b/src/middlewares/withRpcCache.ts
@@ -5,7 +5,7 @@ import serve from '../helpers/requestDeduplicator';
 import { fetchWithKeepAlive, sha256 } from '../helpers/utils';
 
 type Node = { url: string; network: string; headers: Record<string, string> };
-type Entry = { value: any; size: number; expiresAt: number };
+type Entry = { value: string; size: number; expiresAt: number };
 
 const BLOCK_PARAM_INDEX = new Map([
   ['eth_call', 1],
@@ -14,7 +14,7 @@ const BLOCK_PARAM_INDEX = new Map([
   ['eth_getStorageAt', 2]
 ]);
 
-const SKIPPED_HEADERS = new Set([
+const SKIPPED_RESPONSE_HEADERS = new Set([
   'connection',
   'content-encoding',
   'content-length',
@@ -26,6 +26,13 @@ const SKIPPED_HEADERS = new Set([
   'trailer',
   'transfer-encoding',
   'upgrade'
+]);
+
+const SKIPPED_REQUEST_HEADERS = new Set([
+  'accept-encoding',
+  'connection',
+  'content-length',
+  'host'
 ]);
 
 const HEX_BLOCK = /^0x[0-9a-f]+$/i;
@@ -50,15 +57,43 @@ function pinnedBlock(body: any): number | undefined {
   return parseInt(param, 16);
 }
 
-async function rpcCall(node: Node, body: any) {
-  const res = await fetchWithKeepAlive(node.url, {
-    method: 'POST',
-    headers: { Accept: 'application/json', 'Content-Type': 'application/json', ...node.headers },
-    timeout: REQUEST_TIMEOUT,
-    body: JSON.stringify(body)
-  });
+function forwardedRequestHeaders(req: Request) {
+  const headers: Record<string, string> = {};
+  for (const [name, value] of Object.entries(req.headers)) {
+    if (!SKIPPED_REQUEST_HEADERS.has(name) && typeof value === 'string') headers[name] = value;
+  }
+  return headers;
+}
 
-  return { status: res.status, headers: res.headers.raw(), body: await res.json() };
+async function rpcCall(node: Node, body: any, requestHeaders: Record<string, string> = {}) {
+  let status: number;
+  let headers: Record<string, string[]>;
+  let text: string;
+
+  try {
+    const res = await fetchWithKeepAlive(node.url, {
+      method: 'POST',
+      headers: {
+        ...requestHeaders,
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        ...node.headers
+      },
+      timeout: REQUEST_TIMEOUT,
+      body: JSON.stringify(body)
+    });
+    status = res.status;
+    headers = res.headers.raw();
+    text = await res.text();
+  } catch (e: any) {
+    throw new Error(`${node.network} upstream request failed: ${e?.code || e?.name || 'error'}`);
+  }
+
+  try {
+    return { status, headers, text, body: JSON.parse(text) };
+  } catch (e) {
+    return { status, headers, text, body: undefined };
+  }
 }
 
 async function headOf(node: Node): Promise<number | null> {
@@ -96,11 +131,10 @@ function readCache(key: string) {
   return entry.value;
 }
 
-function writeCache(key: string, value: any) {
-  const chars = JSON.stringify(value).length;
-  if (cache.has(key) || chars > MAX_VALUE_SIZE) return;
+function writeCache(key: string, value: unknown) {
+  if (typeof value !== 'string' || cache.has(key) || value.length > MAX_VALUE_SIZE) return;
 
-  const size = 2 * (chars + key.length) + ENTRY_OVERHEAD;
+  const size = 2 * (value.length + key.length) + ENTRY_OVERHEAD;
   cache.set(key, { value, size, expiresAt: Date.now() + ENTRY_TTL });
   cacheSize += size;
 
@@ -125,31 +159,35 @@ export default async function withRpcCache(req: Request, res: Response, next: Ne
   const cached = readCache(key);
   if (cached !== undefined) {
     rpcCacheCount.inc({ status: 'HIT' });
-    return res.json({ jsonrpc: '2.0', id: body.id, result: cached });
+    return res.json({ jsonrpc: '2.0', id: body.id ?? null, result: cached });
   }
 
   rpcCacheCount.inc({ status: 'MISS' });
   const pendingHead = headOf(node);
 
-  let response: { status: number; headers: Record<string, string[]>; body: any };
+  let response: Awaited<ReturnType<typeof rpcCall>>;
   try {
-    response = await serve(key, rpcCall, [node, body]);
-  } catch (e) {
+    response = await serve(key, rpcCall, [node, body, forwardedRequestHeaders(req)]);
+  } catch {
     await pendingHead;
     return res.status(502).json({
       jsonrpc: '2.0',
-      id: body.id,
+      id: body.id ?? null,
       error: { code: -32603, message: 'Upstream request failed' }
     });
   }
 
   for (const [name, values] of Object.entries(response.headers)) {
-    if (!SKIPPED_HEADERS.has(name)) res.setHeader(name, values);
+    if (!SKIPPED_RESPONSE_HEADERS.has(name)) res.setHeader(name, values);
   }
 
   const payload = response.body;
   const isEnvelope = !!payload && typeof payload === 'object' && !Array.isArray(payload);
-  res.status(response.status).json(isEnvelope ? { ...payload, id: body.id } : payload);
+  if (isEnvelope) {
+    res.status(response.status).json({ ...payload, id: body.id ?? null });
+  } else {
+    res.status(response.status).send(response.text);
+  }
 
   const head = await pendingHead;
   if (isEnvelope && head !== null && block <= head - CONFIRMATIONS) {

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -6,6 +6,7 @@ import setGraphqlUrl from './middlewares/setGraphqlUrl';
 import setNode from './middlewares/setNode';
 import subgraphErrorHandler from './middlewares/subgraphErrorHandler';
 import withCachedEthChain from './middlewares/withCachedEthChain';
+import withRpcCache from './middlewares/withRpcCache';
 
 const router = express.Router();
 
@@ -20,6 +21,7 @@ router.use(
   /^\/([^\/]+)$/,
   withCachedEthChain,
   setNode,
+  withRpcCache,
   proxy((req: any) => req._node.url, {
     timeout: REQUEST_TIMEOUT,
     memoizeHost: false,

--- a/tests/e2e/rpcCache.test.ts
+++ b/tests/e2e/rpcCache.test.ts
@@ -268,6 +268,32 @@ describe('RPC cache E2E Tests', () => {
     configuredNodes['10'] = upstreamUrl;
   });
 
+  it('should keep the node url out of the logs when the upstream fails', async () => {
+    configuredNodes['10'] = 'http://127.0.0.1:1/?apikey=SUPERSECRETKEY';
+    const logged: string[] = [];
+    const spy = jest.spyOn(console, 'log').mockImplementation((...args) => {
+      logged.push(args.map(a => (typeof a === 'string' ? a : JSON.stringify(a))).join(' '));
+    });
+
+    try {
+      await request(app).post('/10').send(call('0xcc09', DEEP_BLOCK));
+    } finally {
+      spy.mockRestore();
+      configuredNodes['10'] = upstreamUrl;
+    }
+
+    expect(logged.join('\n')).not.toContain('SUPERSECRETKEY');
+  });
+
+  it('should not store a result that is not a string', async () => {
+    responses.set('0xcc0a', { body: { result: [['a'], ['b']] } });
+
+    await request(app).post('/1').send(call('0xcc0a', DEEP_BLOCK, 1));
+    await request(app).post('/1').send(call('0xcc0a', DEEP_BLOCK, 2));
+
+    expect(countOf('eth_call')).toBe(2);
+  });
+
   it('should answer with jsonrpc 2.0 on both a miss and a hit', async () => {
     const body = { jsonrpc: '1.0', method: 'eth_getCode', params: ['0xcc03', DEEP_BLOCK], id: 1 };
 

--- a/tests/e2e/rpcCache.test.ts
+++ b/tests/e2e/rpcCache.test.ts
@@ -9,20 +9,25 @@ import rpc from '../../src/rpc';
 const HEAD = 20000000;
 const DEEP_BLOCK = '0x1000000';
 const SHALLOW_BLOCK = `0x${HEAD.toString(16)}`;
+const ADDRESS = '0x0000000000000000000000000000000000000001';
+
+type Canned = { status?: number; headers?: Record<string, string>; body: Record<string, any> };
 
 describe('RPC cache E2E Tests', () => {
   let app: express.Application;
   let upstream: Server;
+  let upstreamUrl: string;
   let configuredNodes: Record<string, string>;
-  let originalNode: string | undefined;
+  let originalNodes: Record<string, string | undefined>;
   let calls: string[] = [];
   let answers = 0;
-  const responses = new Map<string, Record<string, any>>();
+  let upstreamDelay = 100;
+  const responses = new Map<string, Canned>();
 
   const call = (data: string, block: string, id: number = 1) => ({
     jsonrpc: '2.0',
     method: 'eth_call',
-    params: [{ to: '0x0000000000000000000000000000000000000001', data }, block],
+    params: [{ to: ADDRESS, data }, block],
     id
   });
 
@@ -40,18 +45,21 @@ describe('RPC cache E2E Tests', () => {
     app.use('/', rpc);
 
     const upstreamApp = express();
-    upstreamApp.use(express.json());
+    upstreamApp.use(express.json({ limit: '4mb' }));
     upstreamApp.post('/', async (req, res) => {
       const { method, params, id } = req.body;
       calls.push(method);
-      await new Promise(resolve => setTimeout(resolve, 100));
+      if (upstreamDelay) await new Promise(resolve => setTimeout(resolve, upstreamDelay));
 
       if (method === 'eth_blockNumber') {
         return res.json({ jsonrpc: '2.0', id, result: `0x${HEAD.toString(16)}` });
       }
 
-      const canned = responses.get(params?.[0]?.data);
-      if (canned) return res.json({ jsonrpc: '2.0', id, ...canned });
+      const canned = responses.get(params?.[0]?.data ?? params?.[0]);
+      if (canned) {
+        if (canned.headers) res.set(canned.headers);
+        return res.status(canned.status ?? 200).json({ jsonrpc: '2.0', id, ...canned.body });
+      }
 
       answers += 1;
       return res.json({ jsonrpc: '2.0', id, result: `0x${answers}` });
@@ -61,18 +69,23 @@ describe('RPC cache E2E Tests', () => {
     });
 
     const { port } = upstream.address() as AddressInfo;
+    upstreamUrl = `http://127.0.0.1:${port}`;
     configuredNodes = nodes as Record<string, string>;
-    originalNode = configuredNodes['1'];
-    configuredNodes['1'] = `http://127.0.0.1:${port}`;
+    originalNodes = { '1': configuredNodes['1'], '10': configuredNodes['10'] };
+    configuredNodes['1'] = upstreamUrl;
+    configuredNodes['10'] = upstreamUrl;
   });
 
   beforeEach(() => {
     calls = [];
+    upstreamDelay = 100;
   });
 
   afterAll(async () => {
-    if (originalNode === undefined) delete configuredNodes['1'];
-    else configuredNodes['1'] = originalNode;
+    for (const [network, url] of Object.entries(originalNodes)) {
+      if (url === undefined) delete configuredNodes[network];
+      else configuredNodes[network] = url;
+    }
     upstream.closeAllConnections();
     await new Promise<void>((resolve, reject) => {
       upstream.close(error => (error ? reject(error) : resolve()));
@@ -102,6 +115,48 @@ describe('RPC cache E2E Tests', () => {
     expect(second.body).toEqual({ jsonrpc: '2.0', id: 2, result: first.body.result });
   });
 
+  it.each([
+    {
+      method: 'eth_call',
+      tag: '0xbb01',
+      params: (t: string) => [{ to: ADDRESS, data: t }, DEEP_BLOCK]
+    },
+    { method: 'eth_getBalance', tag: '0xbb02', params: (t: string) => [t, DEEP_BLOCK] },
+    { method: 'eth_getCode', tag: '0xbb03', params: (t: string) => [t, DEEP_BLOCK] },
+    { method: 'eth_getStorageAt', tag: '0xbb04', params: (t: string) => [t, '0x0', DEEP_BLOCK] }
+  ])('should serve a repeated $method from cache', async ({ method, tag, params }) => {
+    const body = { jsonrpc: '2.0', method, params: params(tag), id: 1 };
+
+    const first = await request(app).post('/1').send(body);
+    expect(countOf(method)).toBe(1);
+
+    calls = [];
+    const second = await request(app)
+      .post('/1')
+      .send({ ...body, id: 2 });
+
+    expect(countOf(method)).toBe(0);
+    expect(second.body).toEqual({ jsonrpc: '2.0', id: 2, result: first.body.result });
+  });
+
+  it("should take eth_getStorageAt's block from the third parameter, not the second", async () => {
+    const body = {
+      jsonrpc: '2.0',
+      method: 'eth_getStorageAt',
+      params: ['0xbb05', SHALLOW_BLOCK, DEEP_BLOCK],
+      id: 1
+    };
+
+    await request(app).post('/1').send(body);
+
+    calls = [];
+    await request(app)
+      .post('/1')
+      .send({ ...body, id: 2 });
+
+    expect(countOf('eth_getStorageAt')).toBe(0);
+  });
+
   it('should never cache or dedupe a latest read', async () => {
     await Promise.all([
       request(app).post('/1').send(call('0xaa03', 'latest', 1)),
@@ -129,16 +184,16 @@ describe('RPC cache E2E Tests', () => {
   });
 
   it.each([
-    { label: 'an upstream error', data: '0xaa05', canned: { error: { code: -32000 } } },
-    { label: 'a result next to an error', data: '0xaa06', canned: { result: '0xf', error: {} } },
-    { label: 'a null result', data: '0xaa07', canned: { result: null } },
+    { label: 'an upstream error', data: '0xaa05', body: { error: { code: -32000 } } },
+    { label: 'a result next to an error', data: '0xaa06', body: { result: '0xf', error: {} } },
+    { label: 'a null result', data: '0xaa07', body: { result: null } },
     {
       label: 'a result above the value size cap',
       data: '0xaa08',
-      canned: { result: '0x'.padEnd(200e3, 'f') }
+      body: { result: '0x'.padEnd(200e3, 'f') }
     }
-  ])('should not cache $label', async ({ data, canned }) => {
-    responses.set(data, canned);
+  ])('should not cache $label', async ({ data, body }) => {
+    responses.set(data, { body });
 
     const first = await request(app).post('/1').send(call(data, DEEP_BLOCK, 1));
     const second = await request(app).post('/1').send(call(data, DEEP_BLOCK, 2));
@@ -147,6 +202,103 @@ describe('RPC cache E2E Tests', () => {
     expect(first.body.id).toBe(1);
     expect(second.body.id).toBe(2);
   });
+
+  it('should forward the upstream status and response headers on a miss', async () => {
+    responses.set('0xcc01', {
+      status: 429,
+      headers: { 'retry-after': '30', 'x-ratelimit-remaining': '0' },
+      body: { error: { code: 429, message: 'slow down' } }
+    });
+
+    const response = await request(app).post('/1').send(call('0xcc01', DEEP_BLOCK));
+
+    expect(response.status).toBe(429);
+    expect(response.headers['retry-after']).toBe('30');
+    expect(response.headers['x-ratelimit-remaining']).toBe('0');
+  });
+
+  it('should answer a failed upstream once, without a second attempt through the proxy', async () => {
+    configuredNodes['10'] = 'http://127.0.0.1:1';
+
+    const response = await request(app).post('/10').send(call('0xcc02', DEEP_BLOCK, 7));
+
+    expect(response.status).toBe(502);
+    expect(response.body).toEqual({
+      jsonrpc: '2.0',
+      id: 7,
+      error: { code: -32603, message: 'Upstream request failed' }
+    });
+
+    configuredNodes['10'] = upstreamUrl;
+  });
+
+  it('should answer with jsonrpc 2.0 on both a miss and a hit', async () => {
+    const body = { jsonrpc: '1.0', method: 'eth_getCode', params: ['0xcc03', DEEP_BLOCK], id: 1 };
+
+    const miss = await request(app).post('/1').send(body);
+    const hit = await request(app).post('/1').send(body);
+
+    expect(countOf('eth_getCode')).toBe(1);
+    expect(miss.body.jsonrpc).toBe('2.0');
+    expect(hit.body.jsonrpc).toBe('2.0');
+  });
+
+  it('should not serve an entry cached against a different node url', async () => {
+    const body = { jsonrpc: '2.0', method: 'eth_getCode', params: ['0xcc04', DEEP_BLOCK], id: 1 };
+
+    await request(app).post('/1').send(body);
+    calls = [];
+    await request(app).post('/1').send(body);
+    expect(countOf('eth_getCode')).toBe(0);
+
+    configuredNodes['1'] = `${upstreamUrl}/?provider=b`;
+    calls = [];
+    await request(app).post('/1').send(body);
+    configuredNodes['1'] = upstreamUrl;
+
+    expect(countOf('eth_getCode')).toBe(1);
+  });
+
+  it('should refetch an entry once its ttl has passed', async () => {
+    const body = { jsonrpc: '2.0', method: 'eth_getCode', params: ['0xcc05', DEEP_BLOCK], id: 1 };
+
+    await request(app).post('/1').send(body);
+    calls = [];
+    await request(app).post('/1').send(body);
+    expect(countOf('eth_getCode')).toBe(0);
+
+    const spy = jest.spyOn(Date, 'now').mockReturnValue(Date.now() + 2 * 3600e3);
+    try {
+      calls = [];
+      await request(app).post('/1').send(body);
+      expect(countOf('eth_getCode')).toBe(1);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('should evict the oldest entries once the byte budget is exceeded', async () => {
+    upstreamDelay = 0;
+    const big = '0x'.padEnd(90e3, 'f');
+    const tagOf = (i: number) => `0xdd${i.toString(16).padStart(4, '0')}`;
+    const send = (tag: string) =>
+      request(app)
+        .post('/1')
+        .send({ jsonrpc: '2.0', method: 'eth_getCode', params: [tag, DEEP_BLOCK], id: 1 });
+
+    for (let i = 0; i < 96; i++) {
+      responses.set(tagOf(i), { body: { result: big } });
+      await send(tagOf(i));
+    }
+
+    calls = [];
+    await send(tagOf(0));
+    expect(countOf('eth_getCode')).toBe(1);
+
+    calls = [];
+    await send(tagOf(95));
+    expect(countOf('eth_getCode')).toBe(0);
+  }, 120e3);
 
   it('should proxy a method outside the cacheable set untouched', async () => {
     const body = {

--- a/tests/e2e/rpcCache.test.ts
+++ b/tests/e2e/rpcCache.test.ts
@@ -11,7 +11,12 @@ const DEEP_BLOCK = '0x1000000';
 const SHALLOW_BLOCK = `0x${HEAD.toString(16)}`;
 const ADDRESS = '0x0000000000000000000000000000000000000001';
 
-type Canned = { status?: number; headers?: Record<string, string>; body: Record<string, any> };
+type Canned = {
+  status?: number;
+  headers?: Record<string, string>;
+  body?: Record<string, any>;
+  raw?: string;
+};
 
 describe('RPC cache E2E Tests', () => {
   let app: express.Application;
@@ -22,6 +27,7 @@ describe('RPC cache E2E Tests', () => {
   let calls: string[] = [];
   let answers = 0;
   let upstreamDelay = 100;
+  let received: Record<string, any> = {};
   const responses = new Map<string, Canned>();
 
   const call = (data: string, block: string, id: number = 1) => ({
@@ -49,6 +55,7 @@ describe('RPC cache E2E Tests', () => {
     upstreamApp.post('/', async (req, res) => {
       const { method, params, id } = req.body;
       calls.push(method);
+      received = req.headers;
       if (upstreamDelay) await new Promise(resolve => setTimeout(resolve, upstreamDelay));
 
       if (method === 'eth_blockNumber') {
@@ -58,7 +65,9 @@ describe('RPC cache E2E Tests', () => {
       const canned = responses.get(params?.[0]?.data ?? params?.[0]);
       if (canned) {
         if (canned.headers) res.set(canned.headers);
-        return res.status(canned.status ?? 200).json({ jsonrpc: '2.0', id, ...canned.body });
+        res.status(canned.status ?? 200);
+        if (canned.raw !== undefined) return res.send(canned.raw);
+        return res.json({ jsonrpc: '2.0', id, ...canned.body });
       }
 
       answers += 1;
@@ -92,6 +101,17 @@ describe('RPC cache E2E Tests', () => {
     });
   });
 
+  it('should look the head up once per network for the whole ttl window', async () => {
+    upstreamDelay = 0;
+
+    await request(app).post('/1').send(call('0xa001', DEEP_BLOCK));
+    await request(app).post('/1').send(call('0xa002', DEEP_BLOCK));
+    await request(app).post('/1').send(call('0xa003', DEEP_BLOCK));
+
+    expect(countOf('eth_call')).toBe(3);
+    expect(countOf('eth_blockNumber')).toBe(1);
+  });
+
   it('should answer two concurrent block-pinned reads with a single upstream request', async () => {
     const [first, second] = await Promise.all([
       request(app).post('/1').send(call('0xaa01', DEEP_BLOCK, 11)),
@@ -102,17 +122,6 @@ describe('RPC cache E2E Tests', () => {
     expect(first.body.result).toBe(second.body.result);
     expect(first.body.id).toBe(11);
     expect(second.body.id).toBe(22);
-  });
-
-  it('should serve a repeated block-pinned read from cache without an upstream request', async () => {
-    const first = await request(app).post('/1').send(call('0xaa02', DEEP_BLOCK));
-    expect(countOf('eth_call')).toBe(1);
-
-    calls = [];
-    const second = await request(app).post('/1').send(call('0xaa02', DEEP_BLOCK, 2));
-
-    expect(countOf('eth_call')).toBe(0);
-    expect(second.body).toEqual({ jsonrpc: '2.0', id: 2, result: first.body.result });
   });
 
   it.each([
@@ -214,6 +223,34 @@ describe('RPC cache E2E Tests', () => {
     expect(response.status).toBe(429);
     expect(response.headers['retry-after']).toBe('30');
     expect(response.headers['x-ratelimit-remaining']).toBe('0');
+  });
+
+  it('should forward a non-JSON upstream body with its status and headers', async () => {
+    responses.set('0xcc06', {
+      status: 429,
+      headers: { 'retry-after': '30', 'content-type': 'text/plain' },
+      raw: 'rate limited'
+    });
+
+    const response = await request(app).post('/1').send(call('0xcc06', DEEP_BLOCK));
+
+    expect(response.status).toBe(429);
+    expect(response.headers['retry-after']).toBe('30');
+    expect(response.text).toBe('rate limited');
+  });
+
+  it('should forward the client request headers to the upstream', async () => {
+    await request(app).post('/1').set('x-client-tag', 'score-api').send(call('0xcc07', DEEP_BLOCK));
+
+    expect(received['x-client-tag']).toBe('score-api');
+  });
+
+  it('should answer a request with no id with a null id', async () => {
+    const response = await request(app)
+      .post('/1')
+      .send({ jsonrpc: '2.0', method: 'eth_getCode', params: ['0xcc08', DEEP_BLOCK] });
+
+    expect(response.body.id).toBeNull();
   });
 
   it('should answer a failed upstream once, without a second attempt through the proxy', async () => {

--- a/tests/e2e/rpcCache.test.ts
+++ b/tests/e2e/rpcCache.test.ts
@@ -184,7 +184,6 @@ describe('RPC cache E2E Tests', () => {
   });
 
   it.each([
-    { label: 'an upstream error', data: '0xaa05', body: { error: { code: -32000 } } },
     { label: 'a result next to an error', data: '0xaa06', body: { result: '0xf', error: {} } },
     { label: 'a null result', data: '0xaa07', body: { result: null } },
     {

--- a/tests/e2e/rpcCache.test.ts
+++ b/tests/e2e/rpcCache.test.ts
@@ -339,7 +339,7 @@ describe('RPC cache E2E Tests', () => {
     }
   });
 
-  it('should evict the oldest entries once the byte budget is exceeded', async () => {
+  it('should evict the least recently used entries once the byte budget is exceeded', async () => {
     upstreamDelay = 0;
     const big = '0x'.padEnd(90e3, 'f');
     const tagOf = (i: number) => `0xdd${i.toString(16).padStart(4, '0')}`;
@@ -348,17 +348,31 @@ describe('RPC cache E2E Tests', () => {
         .post('/1')
         .send({ jsonrpc: '2.0', method: 'eth_getCode', params: [tag, DEEP_BLOCK], id: 1 });
 
-    for (let i = 0; i < 96; i++) {
-      responses.set(tagOf(i), { body: { result: big } });
-      await send(tagOf(i));
-    }
+    const fill = async (from: number, to: number) => {
+      for (let i = from; i < to; i++) {
+        responses.set(tagOf(i), { body: { result: big } });
+        await send(tagOf(i));
+      }
+    };
+
+    await fill(0, 60);
 
     calls = [];
     await send(tagOf(0));
+    expect(countOf('eth_getCode')).toBe(0);
+
+    await fill(60, 100);
+
+    calls = [];
+    await send(tagOf(0));
+    expect(countOf('eth_getCode')).toBe(0);
+
+    calls = [];
+    await send(tagOf(1));
     expect(countOf('eth_getCode')).toBe(1);
 
     calls = [];
-    await send(tagOf(95));
+    await send(tagOf(99));
     expect(countOf('eth_getCode')).toBe(0);
   }, 120e3);
 

--- a/tests/e2e/rpcCache.test.ts
+++ b/tests/e2e/rpcCache.test.ts
@@ -1,0 +1,180 @@
+import { Server } from 'http';
+import { AddressInfo } from 'net';
+import express from 'express';
+import request from 'supertest';
+import { rpcCacheCount } from '../../src/helpers/metrics';
+import { nodes, stop } from '../../src/helpers/nodes';
+import rpc from '../../src/rpc';
+
+const HEAD = 20000000;
+const DEEP_BLOCK = '0x1000000';
+const SHALLOW_BLOCK = `0x${HEAD.toString(16)}`;
+
+describe('RPC cache E2E Tests', () => {
+  let app: express.Application;
+  let upstream: Server;
+  let configuredNodes: Record<string, string>;
+  let originalNode: string | undefined;
+  let calls: string[] = [];
+  let answers = 0;
+  const responses = new Map<string, Record<string, any>>();
+
+  const call = (data: string, block: string, id: number = 1) => ({
+    jsonrpc: '2.0',
+    method: 'eth_call',
+    params: [{ to: '0x0000000000000000000000000000000000000001', data }, block],
+    id
+  });
+
+  const countOf = (method: string) => calls.filter(m => m === method).length;
+
+  async function statuses() {
+    const metric = await rpcCacheCount.get();
+    return Object.fromEntries(metric.values.map(v => [v.labels.status as string, v.value]));
+  }
+
+  beforeAll(async () => {
+    stop();
+    app = express();
+    app.use(express.json());
+    app.use('/', rpc);
+
+    const upstreamApp = express();
+    upstreamApp.use(express.json());
+    upstreamApp.post('/', async (req, res) => {
+      const { method, params, id } = req.body;
+      calls.push(method);
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      if (method === 'eth_blockNumber') {
+        return res.json({ jsonrpc: '2.0', id, result: `0x${HEAD.toString(16)}` });
+      }
+
+      const canned = responses.get(params?.[0]?.data);
+      if (canned) return res.json({ jsonrpc: '2.0', id, ...canned });
+
+      answers += 1;
+      return res.json({ jsonrpc: '2.0', id, result: `0x${answers}` });
+    });
+    upstream = await new Promise(resolve => {
+      const server = upstreamApp.listen(0, '127.0.0.1', () => resolve(server));
+    });
+
+    const { port } = upstream.address() as AddressInfo;
+    configuredNodes = nodes as Record<string, string>;
+    originalNode = configuredNodes['1'];
+    configuredNodes['1'] = `http://127.0.0.1:${port}`;
+  });
+
+  beforeEach(() => {
+    calls = [];
+  });
+
+  afterAll(async () => {
+    if (originalNode === undefined) delete configuredNodes['1'];
+    else configuredNodes['1'] = originalNode;
+    upstream.closeAllConnections();
+    await new Promise<void>((resolve, reject) => {
+      upstream.close(error => (error ? reject(error) : resolve()));
+    });
+  });
+
+  it('should answer two concurrent block-pinned reads with a single upstream request', async () => {
+    const [first, second] = await Promise.all([
+      request(app).post('/1').send(call('0xaa01', DEEP_BLOCK, 11)),
+      request(app).post('/1').send(call('0xaa01', DEEP_BLOCK, 22))
+    ]);
+
+    expect(countOf('eth_call')).toBe(1);
+    expect(first.body.result).toBe(second.body.result);
+    expect(first.body.id).toBe(11);
+    expect(second.body.id).toBe(22);
+  });
+
+  it('should serve a repeated block-pinned read from cache without an upstream request', async () => {
+    const first = await request(app).post('/1').send(call('0xaa02', DEEP_BLOCK));
+    expect(countOf('eth_call')).toBe(1);
+
+    calls = [];
+    const second = await request(app).post('/1').send(call('0xaa02', DEEP_BLOCK, 2));
+
+    expect(countOf('eth_call')).toBe(0);
+    expect(second.body).toEqual({ jsonrpc: '2.0', id: 2, result: first.body.result });
+  });
+
+  it('should never cache or dedupe a latest read', async () => {
+    await Promise.all([
+      request(app).post('/1').send(call('0xaa03', 'latest', 1)),
+      request(app).post('/1').send(call('0xaa03', 'latest', 2))
+    ]);
+    expect(countOf('eth_call')).toBe(2);
+
+    await request(app).post('/1').send(call('0xaa03', 'latest', 3));
+    expect(countOf('eth_call')).toBe(3);
+  });
+
+  it('should dedupe but not store a read above the confirmation depth', async () => {
+    const [first, second] = await Promise.all([
+      request(app).post('/1').send(call('0xaa04', SHALLOW_BLOCK, 1)),
+      request(app).post('/1').send(call('0xaa04', SHALLOW_BLOCK, 2))
+    ]);
+    expect(countOf('eth_call')).toBe(1);
+    expect(first.body.result).toBe(second.body.result);
+
+    calls = [];
+    const third = await request(app).post('/1').send(call('0xaa04', SHALLOW_BLOCK, 3));
+
+    expect(countOf('eth_call')).toBe(1);
+    expect(third.body.result).not.toBe(first.body.result);
+  });
+
+  it.each([
+    { label: 'an upstream error', data: '0xaa05', canned: { error: { code: -32000 } } },
+    { label: 'a result next to an error', data: '0xaa06', canned: { result: '0xf', error: {} } },
+    { label: 'a null result', data: '0xaa07', canned: { result: null } },
+    {
+      label: 'a result above the value size cap',
+      data: '0xaa08',
+      canned: { result: '0x'.padEnd(200e3, 'f') }
+    }
+  ])('should not cache $label', async ({ data, canned }) => {
+    responses.set(data, canned);
+
+    const first = await request(app).post('/1').send(call(data, DEEP_BLOCK, 1));
+    const second = await request(app).post('/1').send(call(data, DEEP_BLOCK, 2));
+
+    expect(countOf('eth_call')).toBe(2);
+    expect(first.body.id).toBe(1);
+    expect(second.body.id).toBe(2);
+  });
+
+  it('should proxy a method outside the cacheable set untouched', async () => {
+    const body = {
+      jsonrpc: '2.0',
+      method: 'eth_getBlockByNumber',
+      params: [DEEP_BLOCK, false],
+      id: 1
+    };
+
+    await request(app).post('/1').send(body);
+    await request(app).post('/1').send(body);
+
+    expect(countOf('eth_getBlockByNumber')).toBe(2);
+  });
+
+  it('should count each cache outcome', async () => {
+    const before = await statuses();
+
+    await request(app).post('/1').send(call('0xaa09', DEEP_BLOCK));
+    await request(app).post('/1').send(call('0xaa09', DEEP_BLOCK));
+    await request(app)
+      .post('/1')
+      .send({ jsonrpc: '2.0', method: 'eth_blockNumber', params: [], id: 1 });
+
+    const after = await statuses();
+
+    expect((after.MISS || 0) - (before.MISS || 0)).toBe(1);
+    expect((after.HIT || 0) - (before.HIT || 0)).toBe(1);
+    expect((after.BYPASS || 0) - (before.BYPASS || 0)).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes #549

Every JSON-RPC body was forwarded to the upstream node untouched, so identical archival reads were paid for every time: two concurrent `eth_call` at the same pinned block are two upstream requests, and so is the same call repeated a second later. The subgraph path has had a cache and in-flight dedup for a while; this brings that shape to the RPC path.

`withRpcCache` sits between `setNode` and the proxy, and takes a request only when the answer cannot go stale:

- the method is one of `eth_call`, `eth_getBalance`, `eth_getStorageAt`, `eth_getCode`, each with its own position for the block argument
- the block argument is an explicit hex quantity, so `latest`, `pending`, `safe`, `finalized` and an omitted block are never cached and never deduped
- the block is at least `CONFIRMATIONS` below that network's head, tracked from one deduped `eth_blockNumber` per network per TTL. A hex block shallower than that is still deduped in flight but never stored, because it can still reorg
- the response carries a non-null `result`, no `error`, and a `result` that is a string, which is what all four of these methods return and what the size accounting assumes

Everything else falls through to the proxy untouched. Entries are keyed by node URL as well as method and params, so repointing a network at a different provider does not keep serving the old one's answers, and they carry a TTL so a wrong entry cannot outlive it. The store is an in-memory Map used as an LRU bounded by an estimated-heap budget and a per-value cap, so a public endpoint cannot grow it without limit. No S3 in this pass.

A miss is answered by the middleware rather than the proxy, so it carries the proxy's behaviour across itself: the client's request headers go up, and the upstream's status and response headers come back, which is what keeps a 429's `Retry-After` reaching the client. A body that is not JSON, which is what rate limiters and edge proxies usually send, is passed through with its status rather than being reinterpreted. Only a failure at the connection level is answered locally, once, with a JSON-RPC error rather than a second attempt through the proxy behind it.

Two choices worth review:

- The metric is a new `rpc_cache_count{status}` rather than a second label on `cache_hit_count`. Adding a label there would leave existing queries matching `cache_hit_count{status="HIT"}` silently aggregating RPC traffic into a number that until now meant subgraphs only.
- `fetchWithKeepAlive` pinned an `https.Agent` on every request, which throws `Protocol "http:" not supported` on an `http://` URL. Node URLs come from the database and the proxy path has always handled both schemes, so the agent is now picked by protocol. The subgraph path is unaffected.

`rpc_request_count` from #554 increments in `setNode`, which runs before this middleware, so on rebase that increment moves after the cache and keeps counting only what leaves the box. Background, and what the upstreams are and are not already caching, is on #549.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


